### PR TITLE
feat: 26630 Add `sorted-diff` command for fine-grained comparison

### DIFF
--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -527,8 +527,8 @@ The command creates two subdirectories under the output directory:
     ...
 ```
 
-- `state1/` contains entries that were either deleted in the second state or modified (showing the old value).
-- `state2/` contains entries that were either added in the second state or modified (showing the new value).
+- `state1/` - entries deleted in the second state or modified (old value), as `{service}_{stateKey}_X.json`.
+- `state2/` - entries added in the second state or modified (new value), as `{service}_{stateKey}_X.json`.
 
 Each file uses the same `{"k":..., "v":...}` JSON-lines format as `sorted-export`, sorted by key bytes. Files under `state1/` and `state2/` are directly comparable file by file (e.g. `diff state1/TokenService_ACCOUNTS_1.json state2/TokenService_ACCOUNTS_1.json`).
 
@@ -549,9 +549,12 @@ java -jar ./validator-<version>.jar /path/to/round1 sorted-diff /path/to/round2 
 
 ### Notes
 
+- Files are chunked by the sorted union of differing keys, so file `X` in `state1/` and file `X` in `state2/` cover the same key range. A modified key always lands in the same file number on both sides.
+- Because of this alignment, entry counts per file are uneven and one side's file may be empty for an add- or delete-only range.
 - Service name and state key should both be either omitted or specified.
 - The data is sorted by the **byte representation of the key** (same ordering and caveats as `sorted-export`).
 - The exporter limits the number of objects per file to 1 million; to customize the limit, use VM parameter `-DmaxObjPerFile`.
+- As with `sorted-export`, ordering is stable across state versions, which is what makes the output usable for differential testing.
 
 ## Compact
 

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -485,6 +485,74 @@ java -jar ./validator-<version>.jar {path-to-state1} diff {path-to-state2} \
 - Service name and state key should both be either omitted or specified.
 - When `--ignore-field` is used, the fast byte-level comparison is still performed first. Parsing and field masking only runs on entries whose raw bytes already differ, so there is no performance impact on identical entries.
 
+## Sorted Diff
+
+[SortedDiffCommand](src/main/java/com/hedera/statevalidation/SortedDiffCommand.java) compares two states and produces sorted diff output grouped by service and state key — the same layout as `sorted-export`, but containing only the entries that differ.
+
+### Usage
+
+1. Download the state files for both rounds.
+2. Run the following command to execute the sorted diff:
+
+```shell
+java -jar [-DmaxObjPerFile=<number>] ./validator-<version>.jar {path-to-state1} sorted-diff {path-to-state2} \
+  --out=<output-directory> \
+  [--service-name=<service-name> --state-key=<state-key>]
+```
+
+### Parameters
+
+- `{path-to-state1}` - Location of the first state files (required).
+- `{path-to-state2}` - Location of the second state files (required).
+
+### Options
+
+- `--out` (or `-o`) - Directory where the resulting diff files are written (required). Must exist before invocation.
+- `--service-name` (or `-s`) - Name of the service to diff. If omitted along with `--state-key`, diffs all states.
+- `--state-key` (or `-k`) - Name of the state to diff. If omitted along with `--service-name`, diffs all states.
+
+### Output Structure
+
+The command creates two subdirectories under the output directory:
+
+```
+<out>/
+  state1/
+    TokenService_ACCOUNTS_1.json
+    ContractService_STORAGE_1.json
+    ...
+  state2/
+    TokenService_ACCOUNTS_1.json
+    ContractService_STORAGE_1.json
+    ...
+```
+
+- `state1/` contains entries that were either deleted in the second state or modified (showing the old value).
+- `state2/` contains entries that were either added in the second state or modified (showing the new value).
+
+Each file uses the same `{"k":..., "v":...}` JSON-lines format as `sorted-export`, sorted by key bytes. Files under `state1/` and `state2/` are directly comparable file by file (e.g. `diff state1/TokenService_ACCOUNTS_1.json state2/TokenService_ACCOUNTS_1.json`).
+
+### Examples
+
+Diff all states between two rounds:
+
+```shell
+java -jar ./validator-<version>.jar /path/to/round1 sorted-diff /path/to/round2 --out=/path/to/result
+```
+
+Diff only accounts between two rounds:
+
+```shell
+java -jar ./validator-<version>.jar /path/to/round1 sorted-diff /path/to/round2 --out=/path/to/result \
+  --service-name=TokenService --state-key=ACCOUNTS
+```
+
+### Notes
+
+- Service name and state key should both be either omitted or specified.
+- The data is sorted by the **byte representation of the key** (same ordering and caveats as `sorted-export`).
+- The exporter limits the number of objects per file to 1 million; to customize the limit, use VM parameter `-DmaxObjPerFile`.
+
 ## Compact
 
 [CompactionCommand](src/main/java/com/hedera/statevalidation/CompactionCommand.java) performs compaction of state files.

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/SortedDiffCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/SortedDiffCommand.java
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.statevalidation;
+
+import com.hedera.statevalidation.exporter.SortedDiffExporter;
+import com.hedera.statevalidation.util.StateUtils;
+import com.swirlds.state.merkle.VirtualMapState;
+import java.io.File;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jspecify.annotations.NonNull;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+/** Compares two states and writes a sorted diff grouped by service and state key. */
+@Command(name = "sorted-diff", description = "Compares two states and creates a sorted, grouped diff.")
+public class SortedDiffCommand implements Runnable {
+
+    private static final Logger log = LogManager.getLogger(SortedDiffCommand.class);
+    private static final String STATE_1 = "STATE1";
+    private static final String STATE_2 = "STATE2";
+
+    @CommandLine.ParentCommand
+    private StateOperatorCommand parent;
+
+    @Parameters(index = "0", description = "Second state directory.")
+    private File stateDir2;
+
+    @Option(
+            names = {"-s", "--service-name"},
+            description = "Service name.")
+    private String serviceName;
+
+    @Option(
+            names = {"-k", "--state-key"},
+            description = "State key.")
+    private String stateKey;
+
+    @Option(
+            names = {"-o", "--out"},
+            required = true,
+            description = "Resulting diff directory path. Must exist before invocation.")
+    private String outputDirStr;
+
+    @Override
+    public void run() {
+        final File outputDirectory = new File(outputDirStr);
+        if (!outputDirectory.exists()) {
+            throw new RuntimeException(outputDirectory.getAbsolutePath() + " does not exist");
+        }
+        if (!outputDirectory.isDirectory()) {
+            throw new RuntimeException(outputDirectory.getAbsolutePath() + " is not a directory");
+        }
+
+        log.info("Initializing the first state...");
+        parent.initializeStateDir();
+        System.setProperty("tmp.dir", getTmpDir(parent.getStateDir()));
+        long start = System.currentTimeMillis();
+        final VirtualMapState state1 = StateUtils.getState(STATE_1);
+        log.info("First state has been initialized in {} seconds.", (System.currentTimeMillis() - start) / 1000);
+
+        log.info("Initializing the second state...");
+        System.setProperty("state.dir", stateDir2.getAbsolutePath());
+        System.setProperty("tmp.dir", getTmpDir(stateDir2));
+        start = System.currentTimeMillis();
+        final VirtualMapState state2 = StateUtils.getState(STATE_2);
+        log.info("Second state has been initialized in {} seconds.", (System.currentTimeMillis() - start) / 1000);
+
+        final SortedDiffExporter exporter = (serviceName == null)
+                ? new SortedDiffExporter(
+                        outputDirectory, state1, state2, SortedExportCommand.prepareServiceNamesAndStateKeys())
+                : new SortedDiffExporter(outputDirectory, state1, state2, serviceName, stateKey);
+        exporter.export();
+    }
+
+    private @NonNull String getTmpDir(final File parentDir) {
+        return parentDir.toPath().resolve("tmp").toFile().getAbsolutePath();
+    }
+}

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/SortedDiffCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/SortedDiffCommand.java
@@ -68,8 +68,7 @@ public class SortedDiffCommand implements Runnable {
         log.info("Second state has been initialized in {} seconds.", (System.currentTimeMillis() - start) / 1000);
 
         final SortedDiffExporter exporter = (serviceName == null)
-                ? new SortedDiffExporter(
-                        outputDirectory, state1, state2, SortedExportCommand.prepareServiceNamesAndStateKeys())
+                ? new SortedDiffExporter(outputDirectory, state1, state2, StateUtils.prepareServiceNamesAndStateKeys())
                 : new SortedDiffExporter(outputDirectory, state1, state2, serviceName, stateKey);
         exporter.export();
     }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/SortedExportCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/SortedExportCommand.java
@@ -1,16 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.statevalidation;
 
-import com.hedera.hapi.platform.state.SingletonType;
-import com.hedera.hapi.platform.state.StateKey;
 import com.hedera.statevalidation.exporter.SortedJsonExporter;
 import com.hedera.statevalidation.util.StateUtils;
-import com.swirlds.base.utility.Pair;
 import com.swirlds.state.merkle.VirtualMapState;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import picocli.CommandLine.Command;
@@ -74,7 +68,7 @@ public class SortedExportCommand implements Runnable {
         if (serviceName == null) {
             // processing all
             final SortedJsonExporter exporter = new SortedJsonExporter(
-                    outputDir, state, prepareServiceNamesAndStateKeys(), firstLeafPath, lastLeafPath);
+                    outputDir, state, StateUtils.prepareServiceNamesAndStateKeys(), firstLeafPath, lastLeafPath);
             exporter.export();
         } else {
             final SortedJsonExporter exporter =
@@ -82,25 +76,5 @@ public class SortedExportCommand implements Runnable {
             exporter.export();
         }
         log.info("Total time is {} seconds.", (System.currentTimeMillis() - start) / 1000);
-    }
-
-    public static List<Pair<String, String>> prepareServiceNamesAndStateKeys() {
-        final List<Pair<String, String>> serviceNamesAndStateKeys = new ArrayList<>();
-        for (final StateKey.KeyOneOfType value : StateKey.KeyOneOfType.values()) {
-            extractStateName(value.protoName(), serviceNamesAndStateKeys);
-        }
-        for (final SingletonType singletonType : SingletonType.values()) {
-            extractStateName(singletonType.protoName(), serviceNamesAndStateKeys);
-        }
-
-        return serviceNamesAndStateKeys;
-    }
-
-    private static void extractStateName(
-            @NonNull final String value, @NonNull final List<Pair<String, String>> serviceNamesAndStateKeys) {
-        final String[] serviceNameStateKey = value.split("_I_");
-        if (serviceNameStateKey.length == 2) {
-            serviceNamesAndStateKeys.add(Pair.of(serviceNameStateKey[0], serviceNameStateKey[1]));
-        }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/SortedExportCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/SortedExportCommand.java
@@ -84,7 +84,7 @@ public class SortedExportCommand implements Runnable {
         log.info("Total time is {} seconds.", (System.currentTimeMillis() - start) / 1000);
     }
 
-    private static List<Pair<String, String>> prepareServiceNamesAndStateKeys() {
+    public static List<Pair<String, String>> prepareServiceNamesAndStateKeys() {
         final List<Pair<String, String>> serviceNamesAndStateKeys = new ArrayList<>();
         for (final StateKey.KeyOneOfType value : StateKey.KeyOneOfType.values()) {
             extractStateName(value.protoName(), serviceNamesAndStateKeys);

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
@@ -26,6 +26,7 @@ import picocli.CommandLine.Parameters;
             ExportCommand.class,
             SortedExportCommand.class,
             DiffCommand.class,
+            SortedDiffCommand.class,
             CompactionCommand.class,
             ApplyBlocksCommand.class,
             BlocksToPcesCommand.class

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedDiffExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedDiffExporter.java
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.statevalidation.exporter;
+
+import static com.hedera.pbj.runtime.ProtoParserTools.TAG_FIELD_OFFSET;
+import static com.hedera.statevalidation.exporter.SortedJsonExporter.SINGLE_STATE_TMPL;
+import static com.hedera.statevalidation.exporter.SortedJsonExporter.keyComparatorFor;
+import static com.hedera.statevalidation.exporter.SortedJsonExporter.writeEntry;
+import static com.hedera.statevalidation.util.ConfigUtils.MAX_OBJ_PER_FILE;
+
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.statevalidation.util.ParallelProcessingUtils;
+import com.hedera.statevalidation.util.StateUtils;
+import com.swirlds.base.utility.Pair;
+import com.swirlds.state.merkle.VirtualMapState;
+import com.swirlds.virtualmap.VirtualMap;
+import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Exports the differences between two states as sorted JSON files, grouped by service and state key
+ * (the same layout as {@link SortedJsonExporter}). For each tracked state:
+ * <ul>
+ *   <li>{@code state1/} holds deletions (present in state1, absent in state2) and the old side of modifications;</li>
+ *   <li>{@code state2/} holds additions (present in state2, absent in state1) and the new side of modifications.</li>
+ * </ul>
+ * Each subdirectory is directly comparable, file by file, to a sorted export of the corresponding single state.
+ */
+public class SortedDiffExporter {
+
+    private static final Logger log = LogManager.getLogger(SortedDiffExporter.class);
+
+    private static final String STATE_1_DIR = "state1";
+    private static final String STATE_2_DIR = "state2";
+
+    private final File resultDir;
+    private final VirtualMapState state1;
+    private final VirtualMapState state2;
+    private final ExecutorService executorService;
+
+    /** Deletions + old side of modifications, keyed by stateId; paths refer to state1. */
+    private final Map<Integer, Set<Pair<Long, Bytes>>> state1DiffByStateId;
+    /** Additions + new side of modifications, keyed by stateId; paths refer to state2. */
+    private final Map<Integer, Set<Pair<Long, Bytes>>> state2DiffByStateId;
+
+    private final Map<Integer, Pair<String, String>> nameByStateId;
+
+    private final AtomicLong objectsProcessed = new AtomicLong(0);
+
+    public SortedDiffExporter(
+            @NonNull final File resultDir,
+            @NonNull final VirtualMapState state1,
+            @NonNull final VirtualMapState state2,
+            @Nullable final String serviceName,
+            @Nullable final String stateKey) {
+        this(resultDir, state1, state2, List.of(Pair.of(serviceName, stateKey)));
+    }
+
+    public SortedDiffExporter(
+            @NonNull final File resultDir,
+            @NonNull final VirtualMapState state1,
+            @NonNull final VirtualMapState state2,
+            @NonNull final List<Pair<String, String>> serviceNameStateKeyList) {
+        this.resultDir = resultDir;
+        this.state1 = state1;
+        this.state2 = state2;
+        this.executorService = Executors.newVirtualThreadPerTaskExecutor();
+        this.state1DiffByStateId = new HashMap<>();
+        this.state2DiffByStateId = new HashMap<>();
+        this.nameByStateId = new HashMap<>();
+
+        serviceNameStateKeyList.forEach(p -> {
+            final int stateId = StateUtils.stateIdFor(p.left(), p.right());
+            final Comparator<Pair<Long, Bytes>> comparator = keyComparatorFor(stateId);
+            state1DiffByStateId.computeIfAbsent(stateId, _ -> new ConcurrentSkipListSet<>(comparator));
+            state2DiffByStateId.computeIfAbsent(stateId, _ -> new ConcurrentSkipListSet<>(comparator));
+            nameByStateId.put(stateId, p);
+        });
+    }
+
+    public void export() {
+        final long startTimestamp = System.currentTimeMillis();
+        final VirtualMap vm1 = state1.getRoot();
+        final VirtualMap vm2 = state2.getRoot();
+        log.info("Start comparing states");
+
+        // state1 -> state2 : deletions and modifications
+        final CompletableFuture<Void> firstPass = CompletableFuture.runAsync(() -> compare(vm1, vm2, true));
+        // state2 -> state1 : additions
+        final CompletableFuture<Void> secondPass = CompletableFuture.runAsync(() -> compare(vm2, vm1, false));
+        CompletableFuture.allOf(firstPass, secondPass).join();
+
+        try {
+            final File dir1 = new File(resultDir, STATE_1_DIR);
+            final File dir2 = new File(resultDir, STATE_2_DIR);
+            Files.createDirectories(dir1.toPath());
+            Files.createDirectories(dir2.toPath());
+
+            final List<CompletableFuture<Void>> writes = new ArrayList<>();
+            writes.addAll(writeInParallel(state1DiffByStateId, vm1, dir1));
+            writes.addAll(writeInParallel(state2DiffByStateId, vm2, dir2));
+            CompletableFuture.allOf(writes.toArray(new CompletableFuture[0])).join();
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            executorService.close();
+        }
+
+        log.info("Diff time: {} seconds", (System.currentTimeMillis() - startTimestamp) / 1000);
+    }
+
+    /**
+     * Traverses {@code vmSource} in parallel and compares each tracked entry against {@code vmTarget}.
+     *
+     * @param isFirstPass when true, collects deletions and modifications; when false, collects additions
+     */
+    private void compare(
+            @NonNull final VirtualMap vmSource, @NonNull final VirtualMap vmTarget, final boolean isFirstPass) {
+        final VirtualMap.Metadata metadata = vmSource.getMetadata();
+        ParallelProcessingUtils.processRange(metadata.getFirstLeafPath(), metadata.getLastLeafPath() + 1, path -> {
+                    final long count = objectsProcessed.incrementAndGet();
+                    if (count % 1_000_000 == 0) {
+                        log.info("Objects processed: {}", count);
+                    }
+
+                    VirtualLeafBytes<?> sourceLeaf = null;
+                    try {
+                        sourceLeaf = vmSource.getRecords().findLeafRecord(path);
+                    } catch (final Exception e) {
+                        log.error("Unexpected error while finding leaf record by path in source", e);
+                    }
+                    if (sourceLeaf == null) {
+                        return;
+                    }
+
+                    final Bytes keyBytes = sourceLeaf.keyBytes();
+                    final int stateId = resolveStateId(keyBytes);
+                    final Set<Pair<Long, Bytes>> sourceBucket =
+                            isFirstPass ? state1DiffByStateId.get(stateId) : state2DiffByStateId.get(stateId);
+                    if (sourceBucket == null) {
+                        return; // not a tracked state
+                    }
+
+                    final Bytes sourceValueBytes = sourceLeaf.valueBytes();
+                    final VirtualLeafBytes<?> targetLeaf = vmTarget.getRecords().findLeafRecord(keyBytes);
+
+                    if (isFirstPass) {
+                        if (targetLeaf == null) {
+                            // Deletion: present in state1, absent in state2
+                            sourceBucket.add(Pair.of(path, keyBytes));
+                        } else if (!Objects.equals(sourceValueBytes, targetLeaf.valueBytes())) {
+                            // Modification: old side to state1, new side to state2
+                            sourceBucket.add(Pair.of(path, keyBytes));
+                            state2DiffByStateId.get(stateId).add(Pair.of(targetLeaf.path(), keyBytes));
+                        }
+                        // Equal: skip
+                    } else if (targetLeaf == null) {
+                        // Addition: present in state2, absent in state1
+                        sourceBucket.add(Pair.of(path, keyBytes));
+                    }
+                })
+                .join();
+    }
+
+    private List<CompletableFuture<Void>> writeInParallel(
+            @NonNull final Map<Integer, Set<Pair<Long, Bytes>>> diffByStateId,
+            @NonNull final VirtualMap vm,
+            @NonNull final File dir) {
+        final List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (final Map.Entry<Integer, Set<Pair<Long, Bytes>>> entry : diffByStateId.entrySet()) {
+            final List<Pair<Long, Bytes>> keys = new ArrayList<>(entry.getValue());
+            if (keys.isEmpty()) {
+                continue;
+            }
+            final Pair<String, String> namePair = nameByStateId.get(entry.getKey());
+            final int fileCount = keys.size() / MAX_OBJ_PER_FILE;
+            for (int i = 0; i <= fileCount; i++) {
+                final String fileName = String.format(SINGLE_STATE_TMPL, namePair.left(), namePair.right(), i + 1);
+                final int start = i * MAX_OBJ_PER_FILE;
+                final int end = Math.min((i + 1) * MAX_OBJ_PER_FILE, keys.size()) - 1;
+                futures.add(CompletableFuture.runAsync(
+                        () -> processRange(keys, vm, dir, fileName, start, end), executorService));
+            }
+        }
+        return futures;
+    }
+
+    private void processRange(
+            @NonNull final List<Pair<Long, Bytes>> keys,
+            @NonNull final VirtualMap vm,
+            @NonNull final File dir,
+            @NonNull final String fileName,
+            final int start,
+            final int end) {
+        final File file = new File(dir, fileName);
+        boolean emptyFile = true;
+        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+            for (int i = start; i <= end; i++) {
+                final long path = keys.get(i).left();
+                final Bytes keyBytes = keys.get(i).right();
+                final VirtualLeafBytes<?> leafRecord = vm.getRecords().findLeafRecord(path);
+                final Bytes valueBytes = leafRecord == null ? Bytes.EMPTY : leafRecord.valueBytes();
+                writeEntry(writer, keyBytes, valueBytes);
+                emptyFile = false;
+            }
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+        if (emptyFile) {
+            file.delete();
+        }
+    }
+
+    /** Resolves the effective stateId, unwrapping the singleton field to its inner id (mirrors collectKeys). */
+    private static int resolveStateId(@NonNull final Bytes keyBytes) {
+        final ReadableSequentialData keyData = keyBytes.toReadableSequentialData();
+        final int tag = keyData.readVarInt(false);
+        final int stateId = tag >> TAG_FIELD_OFFSET;
+        if (stateId == 1) { // singleton wrapper; real id is the next varint
+            return keyData.readVarInt(false);
+        }
+        return stateId;
+    }
+}

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedDiffExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedDiffExporter.java
@@ -236,7 +236,8 @@ public class SortedDiffExporter {
                         log.error("Unexpected error while finding leaf record by path in source", e);
                     }
                     if (sourceLeaf == null) {
-                        return;
+                        throw new IllegalStateException(
+                                "Expected to find a leaf record at path " + path + " in source virtual map");
                     }
 
                     final Bytes keyBytes = sourceLeaf.keyBytes();

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedDiffExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedDiffExporter.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -116,10 +117,12 @@ public class SortedDiffExporter {
             Files.createDirectories(dir1.toPath());
             Files.createDirectories(dir2.toPath());
 
-            final List<CompletableFuture<Void>> writes = new ArrayList<>();
-            writes.addAll(writeInParallel(state1DiffByStateId, vm1, dir1));
-            writes.addAll(writeInParallel(state2DiffByStateId, vm2, dir2));
-            CompletableFuture.allOf(writes.toArray(new CompletableFuture[0])).join();
+            final List<CompletableFuture<Void>> plans = new ArrayList<>();
+            for (final Integer stateId : nameByStateId.keySet()) {
+                plans.add(
+                        CompletableFuture.runAsync(() -> planAndWrite(stateId, dir1, dir2, vm1, vm2), executorService));
+            }
+            CompletableFuture.allOf(plans.toArray(new CompletableFuture[0])).join();
         } catch (final IOException e) {
             throw new RuntimeException(e);
         } finally {
@@ -127,6 +130,89 @@ public class SortedDiffExporter {
         }
 
         log.info("Diff time: {} seconds", (System.currentTimeMillis() - startTimestamp) / 1000);
+    }
+
+    /**
+     * Splits one state's diff into aligned files: file {@code n} on both sides covers the same slice of
+     * the sorted union of differing keys, so a modified key always lands in the same file number on both
+     * sides. Files may be uneven, and one side's file may be empty for a pure add/delete range.
+     */
+    private void planAndWrite(
+            final int stateId, final File dir1, final File dir2, final VirtualMap vm1, final VirtualMap vm2) {
+        final Set<Pair<Long, Bytes>> set1 = state1DiffByStateId.get(stateId);
+        final Set<Pair<Long, Bytes>> set2 = state2DiffByStateId.get(stateId);
+        if (set1.isEmpty() && set2.isEmpty()) {
+            return;
+        }
+
+        final Pair<String, String> namePair = nameByStateId.get(stateId);
+        final Comparator<Pair<Long, Bytes>> cmp = keyComparatorFor(stateId);
+        final Iterator<Pair<Long, Bytes>> it1 = set1.iterator();
+        final Iterator<Pair<Long, Bytes>> it2 = set2.iterator();
+        Pair<Long, Bytes> e1 = it1.hasNext() ? it1.next() : null;
+        Pair<Long, Bytes> e2 = it2.hasNext() ? it2.next() : null;
+
+        final List<CompletableFuture<Void>> writes = new ArrayList<>();
+        int unionIndex = 0;
+        int fileIndex = 0;
+        List<Pair<Long, Bytes>> chunk1 = new ArrayList<>();
+        List<Pair<Long, Bytes>> chunk2 = new ArrayList<>();
+
+        while (e1 != null || e2 != null) {
+            if (unionIndex > 0 && unionIndex % MAX_OBJ_PER_FILE == 0) {
+                emit(writes, namePair, fileIndex++, chunk1, chunk2, dir1, dir2, vm1, vm2);
+                chunk1 = new ArrayList<>();
+                chunk2 = new ArrayList<>();
+            }
+            final int c = (e1 == null) ? 1 : (e2 == null) ? -1 : cmp.compare(e1, e2);
+            if (c < 0) { // deletion, state1 only
+                chunk1.add(e1);
+                e1 = it1.hasNext() ? it1.next() : null;
+            } else if (c > 0) { // addition, state2 only
+                chunk2.add(e2);
+                e2 = it2.hasNext() ? it2.next() : null;
+            } else { // modification, both sides -> same file number
+                chunk1.add(e1);
+                chunk2.add(e2);
+                e1 = it1.hasNext() ? it1.next() : null;
+                e2 = it2.hasNext() ? it2.next() : null;
+            }
+            unionIndex++;
+        }
+        emit(writes, namePair, fileIndex, chunk1, chunk2, dir1, dir2, vm1, vm2);
+
+        CompletableFuture.allOf(writes.toArray(new CompletableFuture[0])).join();
+    }
+
+    private void emit(
+            final List<CompletableFuture<Void>> writes,
+            final Pair<String, String> namePair,
+            final int fileIndex,
+            final List<Pair<Long, Bytes>> chunk1,
+            final List<Pair<Long, Bytes>> chunk2,
+            final File dir1,
+            final File dir2,
+            final VirtualMap vm1,
+            final VirtualMap vm2) {
+        if (chunk1.isEmpty() && chunk2.isEmpty()) {
+            return;
+        }
+        // Both files are written even if one chunk is empty, so file n always exists on both sides.
+        final String fileName = String.format(SINGLE_STATE_TMPL, namePair.left(), namePair.right(), fileIndex + 1);
+        writes.add(CompletableFuture.runAsync(() -> writeFile(new File(dir1, fileName), chunk1, vm1), executorService));
+        writes.add(CompletableFuture.runAsync(() -> writeFile(new File(dir2, fileName), chunk2, vm2), executorService));
+    }
+
+    private void writeFile(final File file, final List<Pair<Long, Bytes>> entries, final VirtualMap vm) {
+        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+            for (final Pair<Long, Bytes> entry : entries) {
+                final Bytes valueBytes =
+                        vm.getRecords().findLeafRecord(entry.left()).valueBytes();
+                writeEntry(writer, entry.right(), valueBytes);
+            }
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedJsonExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedJsonExporter.java
@@ -233,15 +233,20 @@ public class SortedJsonExporter {
             try {
                 final StateKey stateKey1 = StateKey.PROTOBUF.parse(key1.right());
                 final StateKey stateKey2 = StateKey.PROTOBUF.parse(key2.right());
-                if (stateKey1.key().value() instanceof SingletonType) {
+                final Object v1 = stateKey1.key().value();
+                final Object v2 = stateKey2.key().value();
+                final boolean s1 = v1 instanceof SingletonType;
+                final boolean s2 = v2 instanceof SingletonType;
+                if (s1 && s2) {
+                    return 0; // queue metadata singleton is one key; required for union alignment
+                }
+                if (s1) {
                     return -1;
                 }
-                if (stateKey2.key().value() instanceof SingletonType) {
+                if (s2) {
                     return 1;
                 }
-                final Long index1 = (Long) stateKey1.key().value();
-                final Long index2 = (Long) stateKey2.key().value();
-                return index1.compareTo(index2);
+                return ((Long) v1).compareTo((Long) v2);
             } catch (final ParseException e) {
                 throw new RuntimeException(e);
             }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedJsonExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedJsonExporter.java
@@ -87,40 +87,7 @@ public class SortedJsonExporter {
 
         serviceNameStateKeyList.forEach(p -> {
             final int stateId = StateUtils.stateIdFor(p.left(), p.right());
-            final Comparator<Pair<Long, Bytes>> comparator;
-            if (stateId < StateKey.KeyOneOfType.RECORDCACHE_I_TRANSACTION_RECEIPTS.protoOrdinal()) {
-                comparator = (key1, key2) -> {
-                    ReadableSequentialData keyData1 = key1.right().toReadableSequentialData();
-                    keyData1.readVarInt(false); // read tag
-                    keyData1.readVarInt(false); // read value
-
-                    ReadableSequentialData keyData2 = key2.right().toReadableSequentialData();
-                    keyData2.readVarInt(false); // read tag
-                    keyData2.readVarInt(false); // read value
-
-                    return keyData1.readBytes((int) keyData1.remaining())
-                            .compareTo(keyData2.readBytes((int) keyData2.remaining()));
-                };
-            } else {
-                comparator = (key1, key2) -> {
-                    try {
-                        final StateKey stateKey1 = StateKey.PROTOBUF.parse(key1.right());
-                        final StateKey stateKey2 = StateKey.PROTOBUF.parse(key2.right());
-                        // queue metadata
-                        if (stateKey1.key().value() instanceof SingletonType) {
-                            return -1;
-                        }
-                        if (stateKey2.key().value() instanceof SingletonType) {
-                            return 1;
-                        }
-                        final Long index1 = (Long) stateKey1.key().value();
-                        final Long index2 = (Long) stateKey2.key().value();
-                        return index1.compareTo(index2);
-                    } catch (ParseException e) {
-                        throw new RuntimeException(e);
-                    }
-                };
-            }
+            final Comparator<Pair<Long, Bytes>> comparator = keyComparatorFor(stateId);
             keysByExpectedStateIds.computeIfAbsent(stateId, k -> new ConcurrentSkipListSet<>(comparator));
             nameByStateId.put(stateId, p);
         });
@@ -231,45 +198,10 @@ public class SortedJsonExporter {
             for (int i = start; i <= end; i++) {
                 final long path = keys.get(i).left();
                 final Bytes keyBytes = keys.get(i).right();
-                final Bytes valueBytes = vm.getRecords().findLeafRecord(path).valueBytes();
-                final StateKey stateKey;
-                final StateValue stateValue;
-                try {
-                    stateKey = StateKey.PROTOBUF.parse(keyBytes);
-                    stateValue = StateValue.PROTOBUF.parse(
-                            valueBytes.toReadableSequentialData(),
-                            false,
-                            false,
-                            Codec.DEFAULT_MAX_DEPTH,
-                            getVirtualMapValueParseMaxSizeBytes());
-                    if (stateKey.key().kind().equals(StateKey.KeyOneOfType.SINGLETON)) {
-                        JsonUtils.write(
-                                writer,
-                                "{\"v\":%s}\n".formatted(StateUtils.valueToJson(stateValue.value())),
-                                PRETTY_PRINT_ENABLED);
-                    } else if (stateKey.key().value() instanceof Long) { // queue
-                        JsonUtils.write(
-                                writer,
-                                "{\"i\":%s, \"v\":%s}\n"
-                                        .formatted(stateKey.key().value(), StateUtils.valueToJson(stateValue.value())),
-                                PRETTY_PRINT_ENABLED);
-                    } else { // kv
-                        JsonUtils.write(
-                                writer,
-                                "{\"k\":\"%s\", \"v\":\"%s\"}\n"
-                                        .formatted(
-                                                StateUtils.keyToJson(stateKey.key())
-                                                        .replace("\\", "\\\\")
-                                                        .replace("\"", "\\\""),
-                                                StateUtils.valueToJson(stateValue.value())
-                                                        .replace("\\", "\\\\")
-                                                        .replace("\"", "\\\"")),
-                                PRETTY_PRINT_ENABLED);
-                    }
-                    emptyFile = false;
-                } catch (ParseException e) {
-                    throw new RuntimeException(e);
-                }
+                final VirtualLeafBytes<?> leafRecord = vm.getRecords().findLeafRecord(path);
+                final Bytes valueBytes = leafRecord == null ? Bytes.EMPTY : leafRecord.valueBytes();
+                writeEntry(writer, keyBytes, valueBytes);
+                emptyFile = false;
                 long currentObjCount = objectsProcessed.incrementAndGet();
                 if (currentObjCount % MAX_OBJ_PER_FILE == 0) {
                     log.debug("{} objects of {} are processed", currentObjCount, totalNumber);
@@ -281,6 +213,78 @@ public class SortedJsonExporter {
 
         if (emptyFile) {
             file.delete();
+        }
+    }
+
+    public static Comparator<Pair<Long, Bytes>> keyComparatorFor(final int stateId) {
+        if (stateId < StateKey.KeyOneOfType.RECORDCACHE_I_TRANSACTION_RECEIPTS.protoOrdinal()) {
+            return (key1, key2) -> {
+                final ReadableSequentialData keyData1 = key1.right().toReadableSequentialData();
+                keyData1.readVarInt(false); // tag
+                keyData1.readVarInt(false); // value length
+                final ReadableSequentialData keyData2 = key2.right().toReadableSequentialData();
+                keyData2.readVarInt(false);
+                keyData2.readVarInt(false);
+                return keyData1.readBytes((int) keyData1.remaining())
+                        .compareTo(keyData2.readBytes((int) keyData2.remaining()));
+            };
+        }
+        return (key1, key2) -> {
+            try {
+                final StateKey stateKey1 = StateKey.PROTOBUF.parse(key1.right());
+                final StateKey stateKey2 = StateKey.PROTOBUF.parse(key2.right());
+                if (stateKey1.key().value() instanceof SingletonType) {
+                    return -1;
+                }
+                if (stateKey2.key().value() instanceof SingletonType) {
+                    return 1;
+                }
+                final Long index1 = (Long) stateKey1.key().value();
+                final Long index2 = (Long) stateKey2.key().value();
+                return index1.compareTo(index2);
+            } catch (final ParseException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    public static void writeEntry(
+            @NonNull final BufferedWriter writer, @NonNull final Bytes keyBytes, @NonNull final Bytes valueBytes)
+            throws IOException {
+        final StateKey stateKey;
+        final StateValue stateValue;
+        try {
+            stateKey = StateKey.PROTOBUF.parse(keyBytes);
+            stateValue = StateValue.PROTOBUF.parse(
+                    valueBytes.toReadableSequentialData(),
+                    false,
+                    false,
+                    Codec.DEFAULT_MAX_DEPTH,
+                    getVirtualMapValueParseMaxSizeBytes());
+        } catch (final ParseException e) {
+            throw new RuntimeException(e);
+        }
+        if (stateKey.key().kind().equals(StateKey.KeyOneOfType.SINGLETON)) {
+            JsonUtils.write(
+                    writer, "{\"v\":%s}\n".formatted(StateUtils.valueToJson(stateValue.value())), PRETTY_PRINT_ENABLED);
+        } else if (stateKey.key().value() instanceof Long) { // queue
+            JsonUtils.write(
+                    writer,
+                    "{\"i\":%s, \"v\":%s}\n"
+                            .formatted(stateKey.key().value(), StateUtils.valueToJson(stateValue.value())),
+                    PRETTY_PRINT_ENABLED);
+        } else { // kv
+            JsonUtils.write(
+                    writer,
+                    "{\"k\":\"%s\", \"v\":\"%s\"}\n"
+                            .formatted(
+                                    StateUtils.keyToJson(stateKey.key())
+                                            .replace("\\", "\\\\")
+                                            .replace("\"", "\\\""),
+                                    StateUtils.valueToJson(stateValue.value())
+                                            .replace("\\", "\\\\")
+                                            .replace("\"", "\\\"")),
+                    PRETTY_PRINT_ENABLED);
         }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/StateUtils.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/StateUtils.java
@@ -54,6 +54,7 @@ import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.internal.network.Network;
 import com.hedera.pbj.runtime.JsonCodec;
 import com.hedera.pbj.runtime.OneOf;
+import com.swirlds.base.utility.Pair;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.context.PlatformContext;
 import com.swirlds.platform.system.InitTrigger;
@@ -72,6 +73,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.time.InstantSource;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -370,5 +373,25 @@ public final class StateUtils {
         }
 
         throw new IllegalArgumentException(String.format("No state ID found for %s.%s", serviceName, stateKey));
+    }
+
+    public static List<Pair<String, String>> prepareServiceNamesAndStateKeys() {
+        final List<Pair<String, String>> serviceNamesAndStateKeys = new ArrayList<>();
+        for (final StateKey.KeyOneOfType value : StateKey.KeyOneOfType.values()) {
+            extractStateName(value.protoName(), serviceNamesAndStateKeys);
+        }
+        for (final SingletonType singletonType : SingletonType.values()) {
+            extractStateName(singletonType.protoName(), serviceNamesAndStateKeys);
+        }
+
+        return serviceNamesAndStateKeys;
+    }
+
+    private static void extractStateName(
+            @NonNull final String value, @NonNull final List<Pair<String, String>> serviceNamesAndStateKeys) {
+        final String[] serviceNameStateKey = value.split("_I_");
+        if (serviceNameStateKey.length == 2) {
+            serviceNamesAndStateKeys.add(Pair.of(serviceNameStateKey[0], serviceNameStateKey[1]));
+        }
     }
 }

--- a/hedera-state-validator/src/main/java/module-info.java
+++ b/hedera-state-validator/src/main/java/module-info.java
@@ -50,4 +50,5 @@ module com.hedera.state.validator {
     requires com.github.spotbugs.annotations;
     requires info.picocli;
     requires org.apache.logging.log4j;
+    requires org.json;
 }

--- a/hedera-state-validator/src/main/java/module-info.java
+++ b/hedera-state-validator/src/main/java/module-info.java
@@ -50,5 +50,4 @@ module com.hedera.state.validator {
     requires com.github.spotbugs.annotations;
     requires info.picocli;
     requires org.apache.logging.log4j;
-    requires org.json;
 }


### PR DESCRIPTION
**Description**:

Adds a new `sorted-diff` subcommand that compares two state snapshots and produces sorted diff output grouped by service and state key — the same layout as `sorted-export`, but containing only the entries that differ.

### Motivation

The existing `diff` command produces two flat files (`state1-diff.json`, `state2-diff.json`) containing all differing entries across all states in a single unsorted list. For large states with many services this makes it hard to isolate which service/state changed and to correlate the old vs new value of a modified entry. The `sorted-diff` command addresses this by grouping output into per-service/per-state-key files under `state1/` and `state2/` subdirectories, sorted by key bytes — directly comparable file-by-file to `sorted-export` output.

### What changed

**New files:**
- `SortedDiffCommand` — picocli command (`sorted-diff`), same CLI interface as `diff` (`--service-name`, `--state-key`, `--out`). Loads both states, delegates to `SortedDiffExporter`.
- `SortedDiffExporter` — two-pass parallel comparison using the same `ParallelProcessingUtils` traversal as `DiffExporter`:
  - Pass 1 (state1 → state2): collects deletions and old side of modifications.
  - Pass 2 (state2 → state1): collects additions and new side of modifications.
  - Results are accumulated into per-stateId `ConcurrentSkipListSet`s keyed by `(path, keyBytes)`, sorted by `keyComparatorFor(stateId)` (reused from `SortedJsonExporter`), then written in parallel to `state1/` and `state2/` subdirectories using the same `writeEntry` and file-naming conventions as `sorted-export`.

### Output structure

```
<out>/
  state1/
    TokenService_ACCOUNTS_1.json    # deletions + old values of modifications
    ContractService_STORAGE_1.json
    ...
  state2/
    TokenService_ACCOUNTS_1.json    # additions + new values of modifications
    ContractService_STORAGE_1.json
    ...
```

Each file uses the same `{"k":..., "v":...}` JSON-lines format as `sorted-export`, sorted by key bytes, split by `-DmaxObjPerFile`. Files under `state1/` and `state2/` are directly diff-able (`diff state1/TokenService_ACCOUNTS_1.json state2/TokenService_ACCOUNTS_1.json`).

### Usage

```shell
java -jar ./validator-<version>.jar {path-to-state1} sorted-diff {path-to-state2} \
  --out=<output-directory> \
  [--service-name=<service-name> --state-key=<state-key>]
```

### Notes

- When `--service-name` and `--state-key` are omitted, all virtual map states are compared.
- Output is sorted by key bytes (same ordering and caveats as `sorted-export`).
- Uses virtual threads (`Executors.newVirtualThreadPerTaskExecutor()`) for both comparison passes and file writes.
- Respects `-DmaxObjPerFile` for output file splitting.

**Related issue(s)**:

Fixes #26630 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
