### PR TITLE
chore: Disabled uncaught exception reporting on system exit

### DIFF
--- a/platform-sdk/consensus-utility/src/main/java/module-info.java
+++ b/platform-sdk/consensus-utility/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module org.hiero.consensus.utility {
     requires transitive org.hiero.base.utility;
     requires transitive org.hiero.consensus.concurrent;
     requires transitive org.hiero.consensus.model;
+    requires com.swirlds.component.framework;
     requires com.swirlds.logging;
     requires org.hiero.base.concurrent;
     requires org.hiero.consensus.metrics;

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/system/SystemExitUtils.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/system/SystemExitUtils.java
@@ -4,6 +4,7 @@ package org.hiero.consensus.system;
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import static com.swirlds.logging.legacy.LogMarker.STARTUP;
 
+import com.swirlds.component.framework.schedulers.ExceptionHandlers;
 import com.swirlds.logging.legacy.payload.FatalErrorPayload;
 import com.swirlds.logging.legacy.payload.SystemExitPayload;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -48,6 +49,7 @@ public final class SystemExitUtils {
             logger.info(STARTUP.getMarker(), new SystemExitPayload(exitCode.name(), exitCode.getExitCode()));
         }
         System.out.println("Exiting System (" + exitCode.name() + ")");
+        ExceptionHandlers.disableUncaughtExceptionReporting();
         System.exit(exitCode.getExitCode());
         if (haltRuntime) {
             Runtime.getRuntime().halt(exitCode.getExitCode());

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/ExceptionHandlers.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/ExceptionHandlers.java
@@ -25,6 +25,13 @@ public final class ExceptionHandlers {
     public static final UncaughtExceptionHandler NOOP_UNCAUGHT_EXCEPTION = ExceptionHandlers::ignoreException;
 
     /**
+     * Global muzzle for reporting uncaught exceptions; for example, when we are exiting application forcefully,
+     * various threads can fail in surprising ways, but it is not really important, as entire application is being
+     * shut down anyway
+     */
+    private static volatile boolean uncaughtExceptionReporting = true;
+
+    /**
      * Creates a default uncaught exception handler that logs the exception.
      *
      * @param name the name of the component for logging purposes
@@ -70,6 +77,14 @@ public final class ExceptionHandlers {
     }
 
     /**
+     * Stop reporting uncaught exceptions; it is one-way operation and if disabled, cannot be enabled again
+     * To be used only during forceful application shutdown or something similar
+     */
+    public static void disableUncaughtExceptionReporting() {
+        uncaughtExceptionReporting = true;
+    }
+
+    /**
      * Default implementation of an uncaught exception handler that logs the exception.
      */
     private record DefaultUncaughtExceptionHandler(@NonNull String name) implements UncaughtExceptionHandler {
@@ -77,7 +92,9 @@ public final class ExceptionHandlers {
 
         @Override
         public void uncaughtException(final Thread thread, final Throwable exception) {
-            logger.error(EXCEPTION.getMarker(), "Uncaught exception in {}", name, exception);
+            if (uncaughtExceptionReporting) {
+                logger.error(EXCEPTION.getMarker(), "Uncaught exception in {}", name, exception);
+            }
         }
     }
 }


### PR DESCRIPTION
**Description**:

DIsable printing uncaught exceptions if we are in the middle of the System.exit

**Related issue(s)**:

Fixes #26531

**Notes for reviewer**:

Not perfect, but it is probably the only way to catch _every_ possible occurence; otherwise we will play the game forever if the code keeps changing. In some cases it might be happening in 3rd party libraries even and we won't have full control.

Other option is to do a perfectly graceful shutdown through every layer of the application and this is probably multi-month project.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
