### PR TITLE
chore: (0.77) Reduce block buffer size from 150 to 30 blocks (#26425)

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
@@ -39,7 +39,7 @@ import java.time.Duration;
 // spotless:off
 @ConfigData("blockStream.buffer")
 public record BlockBufferConfig(
-        @ConfigProperty(defaultValue = "150") @Min(0) @NetworkProperty int maxBlocks,
+        @ConfigProperty(defaultValue = "30") @Min(0) @NetworkProperty int maxBlocks,
         @ConfigProperty(defaultValue = "1s") @Min(1) @NetworkProperty Duration workerInterval,
         @ConfigProperty(defaultValue = "50.0") @Min(0) @NetworkProperty double actionStageThreshold,
         @ConfigProperty(defaultValue = "20s") @Min(0) @NetworkProperty Duration actionGracePeriod,


### PR DESCRIPTION
Cherry-pick of #26425 to `release/0.77` (backport series item CP 08/12).

Original commit `912892a1ae` (`[main CP 08/12]`). Applied cleanly (1 file).

Source PR: #26425