### PR TITLE
fix: 26653: Increase AsyncInputStream max message size limit

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncInputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncInputStream.java
@@ -51,8 +51,8 @@ public class AsyncInputStream {
 
     private static final String THREAD_NAME = "async-input-stream";
 
-    // maximum message size in bytes - 8mb
-    static final int MAX_MESSAGE_SIZE = 8 * 1024 * 1024;
+    // maximum message size in bytes - 256Mb
+    static final int MAX_MESSAGE_SIZE = 1 << 28;
 
     /** Lifecycle states of the background reader thread. Transitions are monotonic. */
     public enum Status {


### PR DESCRIPTION

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/26653
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
