### PR TITLE
ci(fix): don't run the chaos otter tests twice

### DIFF
--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -299,7 +299,7 @@ jobs:
     uses: ./.github/workflows/808-call-execute-otter-tests.yaml
     with:
       enable-full-otter-tests: true
-      enable-chaos-otter-tests: true
+      enable-chaos-otter-tests: false
       enable-network-log-capture: true
       ref: ${{ needs.commit-info.outputs.sha }}
       java-version: "${{ inputs.java-version }}"
@@ -316,6 +316,7 @@ jobs:
     if: ${{ needs.build.result == 'success' && inputs.enable-chaos-otter-test-suite == 'true' }}
     uses: ./.github/workflows/808-call-execute-otter-tests.yaml
     with:
+      enable-full-otter-tests: false
       enable-chaos-otter-tests: true
       enable-network-log-capture: true
       ref: ${{ needs.commit-info.outputs.sha }}


### PR DESCRIPTION
**Description**:

The chaos otter tests are getting run twice, once on it's own and once as part of the regular otter tests. The regular and chaos tests should be run separately, each controlled by its own input var. This fix properly splits them.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
