### PR TITLE
fix: (0.77) Ops duration throttling for insufficient gas tx (#26438)

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
@@ -271,26 +271,27 @@ public class CustomMessageCallProcessor extends PublicMessageCallProcessor {
                 frame);
         final var gasRequirement = fullResult.gasRequirement();
         final PrecompileContractResult result;
+
+        // ops duration recording
+        final var opsDurationCounter = FrameUtils.opsDurationCounter(frame);
+        final var opsDurationSchedule = opsDurationCounter.schedule();
+        final var opsDurationCost = gasRequirement
+                * opsDurationSchedule.systemContractGasBasedDurationMultiplier()
+                / opsDurationSchedule.multipliersDenominator();
+        opsDurationCounter.recordOpsDurationUnitsConsumed(opsDurationCost);
+        contractMetrics
+                .opsDurationMetrics()
+                .recordSystemContractOpsDuration(
+                        systemContract.getName(),
+                        systemContractAddress.getBytes().toHexString(),
+                        opsDurationCost);
+
         if (frame.getRemainingGas() < gasRequirement) {
             result = PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(INSUFFICIENT_GAS));
         } else {
             if (!fullResult.isRefundGas()) {
                 frame.decrementRemainingGas(gasRequirement);
             }
-
-            final var opsDurationCounter = FrameUtils.opsDurationCounter(frame);
-            final var opsDurationSchedule = opsDurationCounter.schedule();
-            final var opsDurationCost = gasRequirement
-                    * opsDurationSchedule.systemContractGasBasedDurationMultiplier()
-                    / opsDurationSchedule.multipliersDenominator();
-            opsDurationCounter.recordOpsDurationUnitsConsumed(opsDurationCost);
-            contractMetrics
-                    .opsDurationMetrics()
-                    .recordSystemContractOpsDuration(
-                            systemContract.getName(),
-                            systemContractAddress.getBytes().toHexString(),
-                            opsDurationCost);
-
             result = fullResult.result();
         }
         finishPrecompileExecution(context, result, SYSTEM);
@@ -340,19 +341,20 @@ public class CustomMessageCallProcessor extends PublicMessageCallProcessor {
         final var frame = context.frame;
         final var gasRequirement = precompile.gasRequirement(frame.getInputData());
         final PrecompileContractResult result;
+
+        // ops duration recording
+        final var opsDurationCounter = FrameUtils.opsDurationCounter(frame);
+        final var opsDurationSchedule = opsDurationCounter.schedule();
+        final var opsDurationCost = gasRequirement
+                * opsDurationSchedule.precompileGasBasedDurationMultiplier()
+                / opsDurationSchedule.multipliersDenominator();
+        opsDurationCounter.recordOpsDurationUnitsConsumed(opsDurationCost);
+        contractMetrics.opsDurationMetrics().recordPrecompileOpsDuration(precompile.getName(), opsDurationCost);
+
         if (frame.getRemainingGas() < gasRequirement) {
             result = PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(INSUFFICIENT_GAS));
         } else {
             frame.decrementRemainingGas(gasRequirement);
-
-            final var opsDurationCounter = FrameUtils.opsDurationCounter(frame);
-            final var opsDurationSchedule = opsDurationCounter.schedule();
-            final var opsDurationCost = gasRequirement
-                    * opsDurationSchedule.precompileGasBasedDurationMultiplier()
-                    / opsDurationSchedule.multipliersDenominator();
-            opsDurationCounter.recordOpsDurationUnitsConsumed(opsDurationCost);
-            contractMetrics.opsDurationMetrics().recordPrecompileOpsDuration(precompile.getName(), opsDurationCost);
-
             result = precompile.computePrecompile(frame.getInputData(), frame);
             if (result.isRefundGas()) {
                 frame.incrementRemainingGas(gasRequirement);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/processors/CustomMessageCallProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/processors/CustomMessageCallProcessorTest.java
@@ -31,6 +31,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.PrngSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.utils.OpsDurationCounter;
 import com.hedera.node.app.service.contract.impl.hevm.HEVM;
+import com.hedera.node.app.service.contract.impl.hevm.OpsDurationSchedule;
 import com.hedera.node.app.service.contract.impl.state.AbstractMutableEvmAccount;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
@@ -38,6 +39,7 @@ import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +53,7 @@ import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract.PrecompileContractResult;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,7 +62,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CustomMessageCallProcessorTest {
-    private static final long ZERO_GAS_REQUIREMENT = 0L;
+
     private static final long GAS_REQUIREMENT = 2L;
     private static final Bytes INPUT_DATA = Bytes.fromHexString("0x1234");
     private static final Bytes OUTPUT_DATA = Bytes.fromHexString("0x5678");
@@ -69,6 +72,9 @@ class CustomMessageCallProcessorTest {
     private static final Address SENDER_ADDRESS = Address.fromHexString("0x222333444");
     private static final Address RECEIVER_ADDRESS = Address.fromHexString("0x33344455");
     private static final Address ADDRESS_6 = Address.fromHexString("0x6");
+
+    private static final OpsDurationSchedule OPS_DURATION_TEST_SCHEDULE =
+            new OpsDurationSchedule(Collections.nCopies(256, 1L), 1, 1, 1, 1, 1);
 
     @Mock
     private HEVM evm;
@@ -127,10 +133,12 @@ class CustomMessageCallProcessorTest {
 
     @Test
     void callPrngSystemContractHappyPath() {
-        givenPrngCall(ZERO_GAS_REQUIREMENT);
+        final var opsDurationTestCounter = OpsDurationCounter.withSchedule(OPS_DURATION_TEST_SCHEDULE);
+        givenPrngCall(GAS_REQUIREMENT);
+        given(frame.getRemainingGas()).willReturn(GAS_REQUIREMENT);
         given(frame.getValue()).willReturn(Wei.ZERO);
         given(frame.getMessageFrameStack()).willReturn(stack);
-        given(frame.getContextVariable(OPS_DURATION_COUNTER)).willReturn(OpsDurationCounter.disabled());
+        given(frame.getContextVariable(OPS_DURATION_COUNTER)).willReturn(opsDurationTestCounter);
         given(frame.getWorldUpdater()).willReturn(proxyWorldUpdater);
         given(stack.getLast()).willReturn(frame);
         given(result.output()).willReturn(OUTPUT_DATA);
@@ -139,10 +147,11 @@ class CustomMessageCallProcessorTest {
 
         subject.start(frame, operationTracer);
 
+        Assertions.assertEquals(GAS_REQUIREMENT, opsDurationTestCounter.opsDurationUnitsConsumed());
         verify(prngPrecompile)
                 .computeFully(PRNG_CONTRACT_ID, TestHelpers.PRNG_SYSTEM_CONTRACT_ADDRESS.getBytes(), frame);
         verify(result).isRefundGas();
-        verify(frame).decrementRemainingGas(ZERO_GAS_REQUIREMENT);
+        verify(frame).decrementRemainingGas(GAS_REQUIREMENT);
         verify(frame).setOutputData(OUTPUT_DATA);
         verify(frame).setState(MessageFrame.State.CODE_SUCCESS);
         verify(frame).setExceptionalHaltReason(Optional.empty());
@@ -151,11 +160,16 @@ class CustomMessageCallProcessorTest {
 
     @Test
     void callPrngSystemContractInsufficientGas() {
+        final var opsDurationTestCounter = OpsDurationCounter.withSchedule(OPS_DURATION_TEST_SCHEDULE);
+        givenExecutingFrame();
         givenPrngCall(GAS_REQUIREMENT);
         given(frame.getValue()).willReturn(Wei.ZERO);
+        given(frame.getContextVariable(OPS_DURATION_COUNTER)).willReturn(opsDurationTestCounter);
+        when(contractMetrics.opsDurationMetrics()).thenReturn(mock(OpsDurationMetrics.class));
 
         subject.start(frame, operationTracer);
 
+        Assertions.assertEquals(GAS_REQUIREMENT, opsDurationTestCounter.opsDurationUnitsConsumed());
         verify(prngPrecompile)
                 .computeFully(PRNG_CONTRACT_ID, TestHelpers.PRNG_SYSTEM_CONTRACT_ADDRESS.getBytes(), frame);
         verifyHalt(INSUFFICIENT_GAS, false);
@@ -234,19 +248,24 @@ class CustomMessageCallProcessorTest {
 
     @Test
     void haltsAndTracesInsufficientGasIfPrecompileGasRequirementExceedsRemaining() {
+        final var opsDurationTestCounter = OpsDurationCounter.withSchedule(OPS_DURATION_TEST_SCHEDULE);
         givenEvmPrecompileCall();
         given(nativePrecompile.gasRequirement(INPUT_DATA)).willReturn(GAS_REQUIREMENT);
         given(frame.getRemainingGas()).willReturn(1L);
         given(frame.getValue()).willReturn(Wei.ZERO);
+        given(frame.getContextVariable(OPS_DURATION_COUNTER)).willReturn(opsDurationTestCounter);
+        when(contractMetrics.opsDurationMetrics()).thenReturn(mock(OpsDurationMetrics.class));
 
         subject.start(frame, operationTracer);
 
+        Assertions.assertEquals(GAS_REQUIREMENT, opsDurationTestCounter.opsDurationUnitsConsumed());
         verifyHalt(INSUFFICIENT_GAS, false);
         verify(operationTracer).tracePrecompileResult(frame, PRECOMPILE);
     }
 
     @Test
     void updatesFrameBySuccessfulPrecompileResultWithGasRefund() {
+        final var opsDurationTestCounter = OpsDurationCounter.withSchedule(OPS_DURATION_TEST_SCHEDULE);
         givenEvmPrecompileCall();
         when(contractMetrics.opsDurationMetrics()).thenReturn(mock(OpsDurationMetrics.class));
         final var result = new PrecompiledContract.PrecompileContractResult(
@@ -256,11 +275,12 @@ class CustomMessageCallProcessorTest {
         given(frame.getRemainingGas()).willReturn(3L);
         given(frame.getValue()).willReturn(Wei.ZERO);
         given(frame.getMessageFrameStack()).willReturn(stack);
-        given(frame.getContextVariable(OPS_DURATION_COUNTER)).willReturn(OpsDurationCounter.disabled());
+        given(frame.getContextVariable(OPS_DURATION_COUNTER)).willReturn(opsDurationTestCounter);
         given(stack.getLast()).willReturn(frame);
 
         subject.start(frame, operationTracer);
 
+        Assertions.assertEquals(GAS_REQUIREMENT, opsDurationTestCounter.opsDurationUnitsConsumed());
         verify(frame).decrementRemainingGas(GAS_REQUIREMENT);
         verify(frame).incrementRemainingGas(GAS_REQUIREMENT);
         verify(frame).setOutputData(OUTPUT_DATA);
@@ -270,6 +290,7 @@ class CustomMessageCallProcessorTest {
 
     @Test
     void revertsFrameFromPrecompileResult() {
+        final var opsDurationTestCounter = OpsDurationCounter.withSchedule(OPS_DURATION_TEST_SCHEDULE);
         givenEvmPrecompileCall();
         when(contractMetrics.opsDurationMetrics()).thenReturn(mock(OpsDurationMetrics.class));
         final var result = new PrecompiledContract.PrecompileContractResult(
@@ -278,13 +299,14 @@ class CustomMessageCallProcessorTest {
         given(nativePrecompile.gasRequirement(INPUT_DATA)).willReturn(GAS_REQUIREMENT);
         given(frame.getRemainingGas()).willReturn(3L);
         given(frame.getMessageFrameStack()).willReturn(stack);
-        given(frame.getContextVariable(OPS_DURATION_COUNTER)).willReturn(OpsDurationCounter.disabled());
+        given(frame.getContextVariable(OPS_DURATION_COUNTER)).willReturn(opsDurationTestCounter);
         given(stack.getLast()).willReturn(frame);
         given(frame.getContractAddress()).willReturn(Address.ALTBN128_ADD);
         given(frame.getValue()).willReturn(Wei.ZERO);
 
         subject.start(frame, operationTracer);
 
+        Assertions.assertEquals(GAS_REQUIREMENT, opsDurationTestCounter.opsDurationUnitsConsumed());
         verify(frame).decrementRemainingGas(GAS_REQUIREMENT);
         verify(frame).setRevertReason(OUTPUT_DATA);
         verify(frame, never()).setOutputData(OUTPUT_DATA);
@@ -378,26 +400,16 @@ class CustomMessageCallProcessorTest {
     }
 
     private void givenHaltableFrame(@NonNull final AtomicBoolean isHalted) {
-        doAnswer(invocation -> {
+        doAnswer(_ -> {
                     isHalted.set(true);
                     return null;
                 })
                 .when(frame)
                 .setExceptionalHaltReason(any());
         lenient()
-                .doAnswer(invocation ->
-                        isHalted.get() ? MessageFrame.State.EXCEPTIONAL_HALT : MessageFrame.State.NOT_STARTED)
+                .doAnswer(_ -> isHalted.get() ? MessageFrame.State.EXCEPTIONAL_HALT : MessageFrame.State.NOT_STARTED)
                 .when(frame)
                 .getState();
-    }
-
-    private void givenCallWithIsTopLevelTransaction(@NonNull final AtomicBoolean isTopLevelTransaction) {
-        doAnswer(invocation -> {
-                    isTopLevelTransaction.set(false);
-                    return null;
-                })
-                .when(frame)
-                .setExceptionalHaltReason(any());
     }
 
     private void givenCallWithCode(@NonNull final Address contract) {
@@ -441,10 +453,6 @@ class CustomMessageCallProcessorTest {
         given(frame.getInputData()).willReturn(TestHelpers.PRNG_SYSTEM_CONTRACT_ADDRESS.getBytes());
         given(prngPrecompile.computeFully(any(), any(), any()))
                 .willReturn(new FullResult(result, gasRequirement, null));
-    }
-
-    private void verifyHalt(@NonNull final ExceptionalHaltReason reason) {
-        verifyHalt(reason, true);
     }
 
     private void verifyHalt(@NonNull final ExceptionalHaltReason reason, final boolean alsoVerifyTrace) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opsduration/OpsDurationThrottleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opsduration/OpsDurationThrottleTest.java
@@ -59,24 +59,20 @@ public class OpsDurationThrottleTest {
                 restoreDefault(OPS_DURATION_THROTTLE_UNITS_FREED_PER_SECOND));
     }
 
-    @HapiTest
-    @Order(1)
-    @DisplayName("ops duration throttle can overfill but does not exceed a reasonable threshold")
-    public Stream<DynamicTest> overfillOpsDuration() {
+    private Stream<DynamicTest> overfillOpsDuration(long gas, final ResponseCodeEnum expectedStatus) {
         return hapiTest(
                 disableOpsDurationThrottle(),
                 uploadInitCode(OPS_DURATION_THROTTLE),
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(
                             spec,
                             inParallel(IntStream.range(0, 450)
-                                    .mapToObj(i -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "run")
-                                            .gas(200_000L)
+                                    .mapToObj(_ -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "run")
+                                            .gas(gas)
                                             .hasKnownStatusFrom(
-                                                    ResponseCodeEnum.SUCCESS,
-                                                    ResponseCodeEnum.CONSENSUS_GAS_EXHAUSTED)))
+                                                    expectedStatus, ResponseCodeEnum.CONSENSUS_GAS_EXHAUSTED)))
                                     .toArray(HapiSpecOperation[]::new)));
                     // Let the metrics update
                     allRunFor(spec, sleepForSeconds(3));
@@ -88,7 +84,24 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
+    @Order(1)
+    @DisplayName("ops duration throttle can overfill but does not exceed a reasonable threshold")
+    public Stream<DynamicTest> overfillOpsDuration() {
+        return overfillOpsDuration(200_000, ResponseCodeEnum.SUCCESS);
+    }
+
+    @HapiTest
     @Order(2)
+    @DisplayName("ops duration throttle can overfill with InsufficientGas but does not exceed a reasonable threshold")
+    public Stream<DynamicTest> overfillOpsDurationWithInsufficientGasTransactions() {
+        // providing gas a bit more than intrinsic gus, but less than needed for execution (113_000)
+        // we are getting CONTRACT_REVERT_EXECUTED because contract is reverting when child call receives
+        // INSUFFICIENT_GAS
+        return overfillOpsDuration(30_000, ResponseCodeEnum.CONTRACT_REVERT_EXECUTED);
+    }
+
+    @HapiTest
+    @Order(3)
     @DisplayName("call function to not exceed ops duration throttle")
     public Stream<DynamicTest> doNotExceedOpsDuration() {
         return hapiTest(
@@ -96,7 +109,7 @@ public class OpsDurationThrottleTest {
                 uploadInitCode(OPS_DURATION_THROTTLE),
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(spec, contractCall(OPS_DURATION_THROTTLE, "run").gas(200_000L));
                     // Let the metrics update
                     allRunFor(spec, sleepForSeconds(3));
@@ -108,7 +121,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(3)
+    @Order(4)
     @DisplayName("call system contract to exceed ops duration throttle")
     public Stream<DynamicTest> doExceedDurationThrottleWithSystemContract() {
         return hapiTest(
@@ -126,7 +139,7 @@ public class OpsDurationThrottleTest {
                         .addTokenAllowance(SENDER, TOKEN, SYSTEM_CONTRACT_TRANSFER, 1_000_000L)
                         .signedByPayerAnd(SENDER),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     final var tokenAddress = HapiParserUtil.asHeadlongAddress(
                             asAddress(spec.registry().getTokenID(TOKEN)));
                     final var senderAddress = HapiParserUtil.asHeadlongAddress(
@@ -136,7 +149,7 @@ public class OpsDurationThrottleTest {
                     allRunFor(
                             spec,
                             inParallel(IntStream.range(0, 600)
-                                    .mapToObj(i -> sourcing(() -> contractCall(
+                                    .mapToObj(_ -> sourcing(() -> contractCall(
                                                     SYSTEM_CONTRACT_TRANSFER,
                                                     "htsTransferFrom",
                                                     tokenAddress,
@@ -158,7 +171,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(4)
+    @Order(5)
     @DisplayName("call system contract that won't exceed ops duration throttle")
     public Stream<DynamicTest> doNotExceedDurationThrottleWithSystemContract() {
         return hapiTest(
@@ -176,7 +189,7 @@ public class OpsDurationThrottleTest {
                         .addTokenAllowance(SENDER, TOKEN, SYSTEM_CONTRACT_TRANSFER, 1_000_000L)
                         .signedByPayerAnd(SENDER),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     final var tokenAddress = HapiParserUtil.asHeadlongAddress(
                             asAddress(spec.registry().getTokenID(TOKEN)));
                     final var senderAddress = HapiParserUtil.asHeadlongAddress(
@@ -186,7 +199,7 @@ public class OpsDurationThrottleTest {
                     allRunFor(
                             spec,
                             inParallel(IntStream.range(0, 5)
-                                    .mapToObj(i -> sourcing(() -> contractCall(
+                                    .mapToObj(_ -> sourcing(() -> contractCall(
                                                     SYSTEM_CONTRACT_TRANSFER,
                                                     "htsTransferFrom",
                                                     tokenAddress,
@@ -205,7 +218,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(5)
+    @Order(6)
     @DisplayName("call create opcode to exceed ops duration throttle")
     public Stream<DynamicTest> doExceedThrottleWithOpCode() {
         return hapiTest(
@@ -213,11 +226,11 @@ public class OpsDurationThrottleTest {
                 uploadInitCode(OPS_DURATION_THROTTLE),
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(
                             spec,
                             inParallel(IntStream.range(0, 2000)
-                                    .mapToObj(i -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRun")
+                                    .mapToObj(_ -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRun")
                                             .gas(400_000L)
                                             .hasKnownStatusFrom(
                                                     ResponseCodeEnum.SUCCESS,
@@ -233,7 +246,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(6)
+    @Order(7)
     @DisplayName("call create opcode fewer times to not exceed ops duration throttle")
     public Stream<DynamicTest> doNotExceedThrottleWithOpCode() {
         return hapiTest(
@@ -241,11 +254,11 @@ public class OpsDurationThrottleTest {
                 uploadInitCode(OPS_DURATION_THROTTLE),
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(
                             spec,
                             inParallel(IntStream.range(0, 10)
-                                    .mapToObj(i -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRun")
+                                    .mapToObj(_ -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRun")
                                             .gas(400_000L)))
                                     .toArray(HapiSpecOperation[]::new)));
                     // Let the metrics update
@@ -258,7 +271,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(7)
+    @Order(8)
     @DisplayName("call create opcode with expected revert to exceed ops duration throttle")
     public Stream<DynamicTest> doExceedThrottleWithOpCodeReverts() {
         return hapiTest(
@@ -266,11 +279,11 @@ public class OpsDurationThrottleTest {
                 uploadInitCode(OPS_DURATION_THROTTLE),
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(
                             spec,
                             inParallel(IntStream.range(0, 2000)
-                                    .mapToObj(i -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRunRevert")
+                                    .mapToObj(_ -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRunRevert")
                                             .gas(400_000L)
                                             .hasKnownStatusFrom(
                                                     ResponseCodeEnum.CONTRACT_REVERT_EXECUTED,
@@ -286,7 +299,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(8)
+    @Order(9)
     @DisplayName("call create opcode fewer times to not exceed ops duration throttle")
     public Stream<DynamicTest> doNotExceedThrottleWithOpCodeReverts() {
         return hapiTest(
@@ -294,11 +307,11 @@ public class OpsDurationThrottleTest {
                 uploadInitCode(OPS_DURATION_THROTTLE),
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(
                             spec,
                             inParallel(IntStream.range(0, 10)
-                                    .mapToObj(i -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRunRevert")
+                                    .mapToObj(_ -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRunRevert")
                                             .gas(400_000L)
                                             .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)))
                                     .toArray(HapiSpecOperation[]::new)));
@@ -312,7 +325,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(9)
+    @Order(10)
     @DisplayName("call create opcode with expected halt to exceed ops duration throttle")
     public Stream<DynamicTest> doExceedThrottleWithOpCodeHalts() {
         return hapiTest(
@@ -320,11 +333,11 @@ public class OpsDurationThrottleTest {
                 uploadInitCode(OPS_DURATION_THROTTLE),
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(
                             spec,
                             inParallel(IntStream.range(0, 2000)
-                                    .mapToObj(i -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRunHalt")
+                                    .mapToObj(_ -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRunHalt")
                                             .gas(400_000L)
                                             .hasKnownStatusFrom(
                                                     ResponseCodeEnum.CONTRACT_REVERT_EXECUTED,
@@ -340,7 +353,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(10)
+    @Order(11)
     @DisplayName("call create opcode fewer times to not exceed ops duration throttle")
     public Stream<DynamicTest> doNotExceedThrottleWithOpCodeHalts() {
         return hapiTest(
@@ -348,11 +361,11 @@ public class OpsDurationThrottleTest {
                 uploadInitCode(OPS_DURATION_THROTTLE),
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(
                             spec,
                             inParallel(IntStream.range(0, 10)
-                                    .mapToObj(i -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRunHalt")
+                                    .mapToObj(_ -> sourcing(() -> contractCall(OPS_DURATION_THROTTLE, "opsRunHalt")
                                             .gas(400_000L)
                                             .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)))
                                     .toArray(HapiSpecOperation[]::new)));
@@ -366,7 +379,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(11)
+    @Order(12)
     @DisplayName("call nested function to exceed ops duration throttle")
     public Stream<DynamicTest> nestedExceedOpsDuration() {
         return hapiTest(
@@ -375,7 +388,7 @@ public class OpsDurationThrottleTest {
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 // Let's add some initial capacity, but don't free any units once exhausted
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(
                             spec,
                             // First a success that doesn't overflow the ops duration limit
@@ -395,7 +408,7 @@ public class OpsDurationThrottleTest {
     }
 
     @HapiTest
-    @Order(11)
+    @Order(13)
     @DisplayName("account creation consumes ops duration")
     public Stream<DynamicTest> accountCreationConsumesOpsDuration() {
         final var payer = "payer";
@@ -405,7 +418,7 @@ public class OpsDurationThrottleTest {
                 contractCreate(OPS_DURATION_THROTTLE).gas(2_000_000L),
                 cryptoCreate(payer).balance(ONE_HUNDRED_HBARS),
                 enableDefaultOpsDurationThrottleNoRefill(),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     allRunFor(
                             spec,
                             // This call is going to make 25 transfers to subsequent accounts starting at address 10^48

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/validation/ChildCallDataSizeValidationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/validation/ChildCallDataSizeValidationTest.java
@@ -10,8 +10,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
-import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.dsl.annotations.Contract;
 import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
@@ -72,7 +72,7 @@ public class ChildCallDataSizeValidationTest {
                 );
     }
 
-    @HapiTest
+    @LeakyHapiTest
     public Stream<DynamicTest> htsFunctionCallDataSizeValidationTest() {
         return functionCallDataSizeValidationTest(
                 "callAssociateTokens",
@@ -82,7 +82,7 @@ public class ChildCallDataSizeValidationTest {
                 INVALID_ACCOUNT_ID);
     }
 
-    @HapiTest
+    @LeakyHapiTest
     public Stream<DynamicTest> hasFunctionCallDataSizeValidationTest() {
         return functionCallDataSizeValidationTest(
                 "callIsAuthorized",
@@ -92,7 +92,7 @@ public class ChildCallDataSizeValidationTest {
                 SUCCESS);
     }
 
-    @HapiTest
+    @LeakyHapiTest
     public Stream<DynamicTest> hssFunctionCallDataSizeValidationTest() {
         return functionCallDataSizeValidationTest(
                 "callSignSchedule",


### PR DESCRIPTION
Cherry-pick of #26438 to `release/0.77` (backport series item CP 07/12).

Original commit `48dbaad348`. Applied cleanly (4 files) now that CP 05 (#26652) is merged — it modifies `ChildCallDataSizeValidationTest`, which CP 05 introduced.

Verified: `:app-service-contract-impl` (main+test) and `:test-clients` main compile locally.

**Sequencing:** second of the ordered chain (05 ✓ merged → **07** → 09). CP 09 (#26455) should be opened/merged after this.

Source PR: #26438