### PR TITLE
chore: use JDK SHA-384 instead of Bouncy Castle

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/CertificatePemTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/CertificatePemTest.java
@@ -71,7 +71,7 @@ class CertificatePemTest {
         final var genPemPath = Path.of(tmpDir.getPath() + "/generated.pem");
         writeCertificatePemFile(genPemPath, Bytes.wrap("anyString").toByteArray());
         final var exception = assertThrows(IOException.class, () -> readCertificatePemFile(genPemPath));
-        assertThat(exception.getMessage()).contains("problem parsing cert: java.io.EOFException:");
+        assertThat(exception.getMessage()).contains("problem parsing cert: ");
         final var msg = assertThrows(PreCheckException.class, () -> parseX509Certificate(Bytes.wrap("anyString")));
         assertEquals(ResponseCodeEnum.INVALID_GOSSIP_CA_CERTIFICATE, msg.responseCode());
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicIsAuthorizedTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicIsAuthorizedTest.java
@@ -60,6 +60,7 @@ import com.hedera.services.bdd.utils.Signing;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -67,7 +68,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
-import org.bouncycastle.jcajce.provider.digest.SHA384.Digest;
 import org.hiero.base.utility.CommonUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -339,7 +339,8 @@ class AtomicIsAuthorizedTest {
                     uploadInitCode(HRC632_CONTRACT),
                     contractCreate(HRC632_CONTRACT),
                     withOpContext((spec, opLog) -> {
-                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var messageHash =
+                                MessageDigest.getInstance("SHA-384").digest("submit".getBytes());
 
                         final var edKey = spec.registry().getKey(ED25519_KEY);
                         final var privateKey = spec.keys()
@@ -427,7 +428,8 @@ class AtomicIsAuthorizedTest {
                     uploadInitCode(HRC632_CONTRACT),
                     contractCreate(HRC632_CONTRACT),
                     withOpContext((spec, opLog) -> {
-                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var messageHash =
+                                MessageDigest.getInstance("SHA-384").digest("submit".getBytes());
                         final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
                         final var signedBytes = Signing.signMessage(messageHash, privateKey);
 
@@ -470,7 +472,8 @@ class AtomicIsAuthorizedTest {
                     uploadInitCode(HRC632_CONTRACT),
                     contractCreate(HRC632_CONTRACT),
                     withOpContext((spec, opLog) -> {
-                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var messageHash =
+                                MessageDigest.getInstance("SHA-384").digest("submit".getBytes());
                         final var edKey = spec.registry().getKey(ED25519_KEY);
                         final var privateKey = spec.keys()
                                 .getEd25519PrivateKey(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip632/IsAuthorizedTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip632/IsAuthorizedTest.java
@@ -56,12 +56,12 @@ import com.hedera.services.bdd.suites.utils.contracts.BoolResult;
 import com.hedera.services.bdd.utils.Signing;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
-import org.bouncycastle.jcajce.provider.digest.SHA384.Digest;
 import org.hiero.base.utility.CommonUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -303,7 +303,8 @@ public class IsAuthorizedTest {
                     uploadInitCode(HRC632_CONTRACT),
                     contractCreate(HRC632_CONTRACT),
                     withOpContext((spec, opLog) -> {
-                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var messageHash =
+                                MessageDigest.getInstance("SHA-384").digest("submit".getBytes());
 
                         final var edKey = spec.registry().getKey(ED25519_KEY);
                         final var privateKey = spec.keys()
@@ -382,7 +383,8 @@ public class IsAuthorizedTest {
                     uploadInitCode(HRC632_CONTRACT),
                     contractCreate(HRC632_CONTRACT),
                     withOpContext((spec, opLog) -> {
-                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var messageHash =
+                                MessageDigest.getInstance("SHA-384").digest("submit".getBytes());
                         final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
                         final var signedBytes = Signing.signMessage(messageHash, privateKey);
 
@@ -422,7 +424,8 @@ public class IsAuthorizedTest {
                     uploadInitCode(HRC632_CONTRACT),
                     contractCreate(HRC632_CONTRACT),
                     withOpContext((spec, opLog) -> {
-                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var messageHash =
+                                MessageDigest.getInstance("SHA-384").digest("submit".getBytes());
                         final var edKey = spec.registry().getKey(ED25519_KEY);
                         final var privateKey = spec.keys()
                                 .getEd25519PrivateKey(

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 }
 
 val besu = "26.2.0"
-val bouncycastle = "1.84"
+val bouncycastle = "1.85"
 val dagger = "2.59.2"
 val eclipseCollections = "13.0.0"
 val grpc = "1.81.0"


### PR DESCRIPTION
**Description**:
Two test files in the Consensus Node repository use the `org.bouncycastle.jcajce.provider.digest.SHA384.Digest` currently: https://github.com/search?q=repo%3Ahiero-ledger%2Fhiero-consensus-node+%22import+org.bouncycastle.jcajce.provider.digest.S%22&type=code

However, JDK has a built-in support for the `SHA-384` hashing in its `MessageDigest` class already.

An adhoc benchmark:
```java
    @Benchmark
    @OperationsPerInvocation(INVOCATIONS)
    public void sha384bc(final KeccakState state, final Blackhole blackhole) throws Throwable {
        for (int i = 0; i < INVOCATIONS; i++) {
            blackhole.consume(new SHA384.Digest().digest(state.msg));
        }
    }
    @Benchmark
    @OperationsPerInvocation(INVOCATIONS)
    public void sha384jdk(final KeccakState state, final Blackhole blackhole) throws Throwable {
        for (int i = 0; i < INVOCATIONS; i++) {
            blackhole.consume(MessageDigest.getInstance("SHA-384").digest(state.msg));
        }
    }
```

produces the following results:

```
Benchmark                                     Mode  Cnt     Score    Error   Units
Keccak256Bench.sha384bc                      thrpt   15  2178.196 ±  8.521  ops/ms
Keccak256Bench.sha384bc:gc.alloc.rate        thrpt   15  1861.224 ±  7.279  MB/sec
Keccak256Bench.sha384bc:gc.alloc.rate.norm   thrpt   15   896.000 ±  0.001    B/op
Keccak256Bench.sha384bc:gc.count             thrpt   15   466.000           counts
Keccak256Bench.sha384bc:gc.time              thrpt   15   249.000               ms
Keccak256Bench.sha384jdk                     thrpt   15  8425.171 ± 46.406  ops/ms
Keccak256Bench.sha384jdk:gc.alloc.rate       thrpt   15  3085.341 ± 16.994  MB/sec
Keccak256Bench.sha384jdk:gc.alloc.rate.norm  thrpt   15   384.000 ±  0.001    B/op
Keccak256Bench.sha384jdk:gc.count            thrpt   15   772.000           counts
Keccak256Bench.sha384jdk:gc.time             thrpt   15   398.000               ms
```

We can see that the JDK implementation is 4 times faster than the Bouncy Castle one. But it performs more memory allocations than the Bouncy Castle one (3 MB/s vs 1.8 MB/s). So if we used SHA-384 hashing in the production code path, we'd probably want to run more performance tests to ensure the JDK implementation doesn't produce any GC-related issues.

However, since we use the SHA-384 hashing in tests only, it should be totally fine to remove a dependency on a 3rd party library and use a built-in JDK SHA-384 hashing instead.

I'm also upgrading the Bouncy Castle dependency to 1.85 to address a requirement from Snyk: https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/30858901963/job/91837545760?pr=26678 
And this upgrade also requires a small modification in a unit test w.r.t. expected exception message - Bouncy Castle seems to have changed the message in the new version.

**Related issue(s)**:

Fixes #26676

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
