### PR TITLE
ci(fix): show proper ref name in the slack templates

### DIFF
--- a/.github/workflows/300-flow-build-application.yaml
+++ b/.github/workflows/300-flow-build-application.yaml
@@ -254,13 +254,13 @@ jobs:
       - name: Build Test Failure Slack Payload
         if: ${{ steps.report-category.outputs.category == 'test' }}
         env:
-          REF_NAME: ${{ github.ref_name }}
           MATS_TESTS_RESULT: ${{ needs.mats-tests.result }}
           DEPLOY_CI_TRIGGER_RESULT: ${{ needs.deploy-ci-trigger.result }}
           FAILED_TESTS: ${{ needs.mats-tests.outputs.failed-tests }}
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.fetch-commit-info.outputs.commit-hash }}
           COMMIT_AUTHOR: ${{ steps.fetch-commit-info.outputs.commit-author }}
           SLACK_USER_ID: ${{ steps.find-commit-author-slack.outputs.slack-user-id }}
+          REF_NAME: ${{ github.ref_name }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -271,6 +271,7 @@ jobs:
         env:
           MATS_TESTS_RESULT: ${{ needs.mats-tests.result }}
           DEPLOY_CI_TRIGGER_RESULT: ${{ needs.deploy-ci-trigger.result }}
+          REF_NAME: ${{ github.ref_name }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: gomplate -f .github/workflows/templates/slack-mats-env-failure-detailed.json.tpl -o slack_payload.json

--- a/.github/workflows/300-flow-build-application.yaml
+++ b/.github/workflows/300-flow-build-application.yaml
@@ -254,6 +254,7 @@ jobs:
       - name: Build Test Failure Slack Payload
         if: ${{ steps.report-category.outputs.category == 'test' }}
         env:
+          REF_NAME: ${{ github.ref_name }}
           MATS_TESTS_RESULT: ${{ needs.mats-tests.result }}
           DEPLOY_CI_TRIGGER_RESULT: ${{ needs.deploy-ci-trigger.result }}
           FAILED_TESTS: ${{ needs.mats-tests.outputs.failed-tests }}

--- a/.github/workflows/301-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/301-flow-deploy-release-artifact.yaml
@@ -384,6 +384,7 @@ jobs:
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.fetch-commit-info.outputs.commit-hash }}
           COMMIT_AUTHOR: ${{ steps.fetch-commit-info.outputs.commit-author }}
           SLACK_USER_ID: ${{ steps.find-commit-author-slack.outputs.slack-user-id }}
+          REF_NAME: ${{ github.ref_name }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: gomplate -f .github/workflows/templates/slack-deploy-release-failure.json.tpl -o slack_payload.json

--- a/.github/workflows/support/tests/test-gomplate-templates.sh
+++ b/.github/workflows/support/tests/test-gomplate-templates.sh
@@ -62,6 +62,7 @@ for template in "${TEMPLATES_DIR}"/*.tpl; do
 
   if ! env "${full_env[@]}" gomplate -f "${template}" -o /dev/null 2>/dev/null; then
     echo "FAIL: ${name} — did not render with all required vars set"
+#    env "${full_env[@]}" gomplate -f "${template}"
     template_failed=1
   fi
 

--- a/.github/workflows/support/tests/test-gomplate-templates.sh
+++ b/.github/workflows/support/tests/test-gomplate-templates.sh
@@ -62,7 +62,6 @@ for template in "${TEMPLATES_DIR}"/*.tpl; do
 
   if ! env "${full_env[@]}" gomplate -f "${template}" -o /dev/null 2>/dev/null; then
     echo "FAIL: ${name} — did not render with all required vars set"
-#    env "${full_env[@]}" gomplate -f "${template}"
     template_failed=1
   fi
 

--- a/.github/workflows/templates/slack-deploy-release-failure.json.tpl
+++ b/.github/workflows/templates/slack-deploy-release-failure.json.tpl
@@ -18,7 +18,7 @@
           "type": "section",
           "text": {
             "type": "mrkdwn",
-            "text": "*Deploy Production Release job resulted in failure on `main`. See status below.*"
+            "text": {{ printf "*Deploy Production Release job resulted in failure on `%s`. See status below.* " (getenv "REF_NAME" | required "REF_NAME must be set") (getenv "REF_NAME") | data.ToJSON }}
           },
           "fields": [
             {

--- a/.github/workflows/templates/slack-mats-env-failure-detailed.json.tpl
+++ b/.github/workflows/templates/slack-mats-env-failure-detailed.json.tpl
@@ -18,7 +18,7 @@
           "type": "section",
           "text": {
             "type": "mrkdwn",
-            "text": "*Environment issue detected on `main`.*"
+            "text": {{ printf "*Environment issue detected on `%s`. See status below.* " (getenv "REF_NAME" | required "REF_NAME must be set") (getenv "REF_NAME") | data.ToJSON }}
           },
           "fields": [
             {

--- a/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
+++ b/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
@@ -18,7 +18,7 @@
           "type": "section",
           "text": {
             "type": "mrkdwn",
-            "text": {{ printf "*MATS test failure on `<%s/%s/tree/%s|%s>`. See status below.* " $serverUrl $repository (getenv "REF_NAME" | required "REF_NAME must be set") (getenv "REF_NAME") | data.ToJSON }}
+            "text": {{ printf "*MATS test failure on `%s`. See status below.* " (getenv "REF_NAME" | required "REF_NAME must be set") (getenv "REF_NAME") | data.ToJSON }}
           },
           "fields": [
             {

--- a/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
+++ b/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
@@ -18,7 +18,7 @@
           "type": "section",
           "text": {
             "type": "mrkdwn",
-            "text": "*MATS test failure on `main`. See status below.*"
+            "text": {{ printf "*MATS test failure on `<%s/%s/tree/%s|%s>`. See status below.* " $serverUrl $repository (getenv "REF_NAME" | required "REF_NAME must be set") (getenv "REF_NAME") | data.ToJSON }}
           },
           "fields": [
             {


### PR DESCRIPTION
The slack output for MATS failures always claims it is the main branch that failed, even when it's a different branch. This is because the template hard codes the name of the branch. This PR uses the real branch name instead.

* add ref_name to env for slack mats template
* use ref_name in the slack-mats-test-failure-detailed.json.tpl template

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #https://github.com/hiero-ledger/hiero-consensus-node/issues/26679

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
