### PR TITLE
fix: bump cutover solo to v0.84.1; make 103 adhoc Solo version track .citr-env

### DIFF
--- a/.github/workflows/103-user-solo-tests-adhoc.yaml
+++ b/.github/workflows/103-user-solo-tests-adhoc.yaml
@@ -9,10 +9,10 @@ on:
         required: true
         type: string
       solo-version:
-        description: "[All] Solo version to install."
-        required: true
+        description: "[All] Solo version to install. Blank → the pinned adhoc-solo-version from .citr-env (recommended)."
+        required: false
         type: string
-        default: "0.79.0"
+        default: ""
       scenario:
         description: "Which Solo test scenario to run."
         required: true
@@ -105,7 +105,10 @@ jobs:
 
   extract-citr-vars:
     name: Extract CITR Vars
-    if: ${{ inputs.scenario == '077-to-078-cutover' }}
+    # Runs for every scenario. Non-cutover jobs read adhoc-solo-version from it as the default
+    # Solo version when the solo-version input is left blank; the 077-to-078 cutover job reads
+    # cutover-solo-version. It must stay unconditional: a gated job would be "skipped", and a
+    # skipped need skips its dependents, so gating it would skip every non-cutover scenario.
     uses: ./.github/workflows/855-call-extract-citr-vars.yaml
     with:
       ref: ${{ inputs.ref }}
@@ -116,6 +119,7 @@ jobs:
     name: "Solo Jumpstart for Wrapped Record Blocks (WRB)"
     needs:
       - extract-jdk-version
+      - extract-citr-vars
     if: ${{ inputs.scenario == 'jumpstart' }}
     # Kind runs on the relay runner; the remote cluster is only reachable from the SDLT runner (Teleport).
     runs-on: ${{ inputs.cluster-target == 'remote-sdlt-n6' && 'hl-cn-sdlt-lin-lg' || 'hl-cn-rpc-relay-lin-lg' }}
@@ -152,8 +156,13 @@ jobs:
 
       - name: Install Solo
         env:
-          SOLO_VERSION: ${{ inputs.solo-version }}
+          SOLO_VERSION: ${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-solo-version }}
         run: |
+          set -eo pipefail
+          if [[ -z "${SOLO_VERSION}" ]]; then
+            echo "::error::No Solo version resolved: 'solo-version' input is blank and adhoc-solo-version is missing from .citr-env."
+            exit 1
+          fi
           npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 
@@ -315,6 +324,7 @@ jobs:
     name: "Solo E2E Block Stream Cutover"
     needs:
       - extract-jdk-version
+      - extract-citr-vars
     if: ${{ inputs.scenario == 'e2e-block-stream-cutover' }}
     runs-on: ${{ inputs.cluster-target == 'remote-sdlt-n6' && 'hl-cn-sdlt-lin-lg' || 'hl-cn-rpc-relay-lin-lg' }}
     # 12-step cutover fits in ~150m; the added TCK Step 13 (repo clones, sdk-server, full suite)
@@ -353,8 +363,13 @@ jobs:
 
       - name: Install Solo
         env:
-          SOLO_VERSION: ${{ inputs.solo-version }}
+          SOLO_VERSION: ${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-solo-version }}
         run: |
+          set -eo pipefail
+          if [[ -z "${SOLO_VERSION}" ]]; then
+            echo "::error::No Solo version resolved: 'solo-version' input is blank and adhoc-solo-version is missing from .citr-env."
+            exit 1
+          fi
           npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 
@@ -528,6 +543,7 @@ jobs:
     name: "Solo 0.75 -> 0.76 TSS Upgrade"
     needs:
       - extract-jdk-version
+      - extract-citr-vars
     if: ${{ inputs.scenario == '075-to-076-tss' }}
     runs-on: hl-cn-rpc-relay-lin-lg
     timeout-minutes: 120
@@ -563,8 +579,13 @@ jobs:
 
       - name: Install Solo
         env:
-          SOLO_VERSION: ${{ inputs.solo-version }}
+          SOLO_VERSION: ${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-solo-version }}
         run: |
+          set -eo pipefail
+          if [[ -z "${SOLO_VERSION}" ]]; then
+            echo "::error::No Solo version resolved: 'solo-version' input is blank and adhoc-solo-version is missing from .citr-env."
+            exit 1
+          fi
           npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 
@@ -825,6 +846,7 @@ jobs:
     name: "Solo E2E Backpressure (Block Node Outage)"
     needs:
       - extract-jdk-version
+      - extract-citr-vars
     if: ${{ inputs.scenario == 'e2e-backpressure' }}
     # Kind-only: the script provisions its own ephemeral Kind cluster on the runner
     # and scales block-node workloads directly, so cluster-target is ignored.
@@ -848,8 +870,15 @@ jobs:
           node-version: "20.18.0"
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-solo-version }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version }}"
+          set -eo pipefail
+          if [[ -z "${SOLO_VERSION}" ]]; then
+            echo "::error::No Solo version resolved: 'solo-version' input is blank and adhoc-solo-version is missing from .citr-env."
+            exit 1
+          fi
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 
       - name: Setup Kind
@@ -919,6 +948,7 @@ jobs:
     name: "Solo WRB Streaming to Block Node"
     needs:
       - extract-jdk-version
+      - extract-citr-vars
     if: ${{ inputs.scenario == 'wrb-streaming' }}
     runs-on: ${{ inputs.cluster-target == 'remote-sdlt-n6' && 'hl-cn-sdlt-lin-lg' || 'hl-cn-rpc-relay-lin-lg' }}
     timeout-minutes: 120
@@ -945,8 +975,13 @@ jobs:
 
       - name: Install Solo
         env:
-          SOLO_VERSION: ${{ inputs.solo-version }}
+          SOLO_VERSION: ${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-solo-version }}
         run: |
+          set -eo pipefail
+          if [[ -z "${SOLO_VERSION}" ]]; then
+            echo "::error::No Solo version resolved: 'solo-version' input is blank and adhoc-solo-version is missing from .citr-env."
+            exit 1
+          fi
           npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 

--- a/.github/workflows/support/citr/.citr-env
+++ b/.github/workflows/support/citr/.citr-env
@@ -1,7 +1,7 @@
 citr-solo-version=0.79.1
 adhoc-solo-version=0.79.1
 adhoc-xts-solo-version=0.79.1
-cutover-solo-version=0.84.0
+cutover-solo-version=0.84.1
 citr-mirror-node-version=0.158.0
 mqpt-cluster=Dallas_n10
 tck-version=v0.12.3

--- a/hedera-node/test-clients/scripts/solo/e2e-backpressure/solo-e2e-block-node-outage.sh
+++ b/hedera-node/test-clients/scripts/solo/e2e-backpressure/solo-e2e-block-node-outage.sh
@@ -9,7 +9,7 @@ export SOLO_CLUSTER_NAME="solo"
 export SOLO_NAMESPACE="solo"
 export SOLO_CLUSTER_SETUP_NAMESPACE="solo-cluster"
 export SOLO_DEPLOYMENT="solo-deployment"
-# keep in lockstep with the Solo version's mirror chart default (solo 0.79.0 -> 0.156.0);
+# keep in lockstep with the Solo version's mirror chart default (solo 0.79.1 -> 0.156.0);
 # on 0.157+ Solo's HIERO_MIRROR_IMPORTER_BLOCK_NODES_* env wiring no longer binds and the
 # importer crash-loops at startup
 export MIRROR_NODE_VERSION="v0.156.0"

--- a/hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-e2e-block-stream-cutover.sh
+++ b/hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-e2e-block-stream-cutover.sh
@@ -345,7 +345,7 @@ MIRROR_BLOCK_CUTOVER_HAPIVERSION="${MIRROR_BLOCK_CUTOVER_HAPIVERSION:-}"
 # version, satisfying Solo's no-downgrade guard (assertUpgradeVersionNotOlder). Block-cutover env
 # wiring needs MN >= 0.153.1 to honor the HIERO_MIRROR_IMPORTER_BLOCK_CUTOVER_* keys; 0.156.0 does.
 # COUPLING: this must stay >= the mirror chart default of the pinned Solo (workflow `solo-version`,
-# currently 0.79.0 -> default 0.156.0). If you bump solo-version, bump this in lockstep or the add
+# currently 0.79.1 -> default 0.156.0). If you bump solo-version, bump this in lockstep or the add
 # itself can deploy a newer default than this pin and the Step 9 upgrade then reads as a downgrade.
 MIRROR_NODE_VERSION="${MIRROR_NODE_VERSION:-v0.158.0}"
 


### PR DESCRIPTION
## Summary
Follow-up to #26706

## Changes
- **`.citr-env`**: `cutover-solo-version` `0.84.0 → 0.84.1` (stays on the `0.84` line the
  077→078 cutover requires).
- **`103-user-solo-tests-adhoc.yaml`**: `solo-version` default is now blank and resolves
  `inputs.solo-version || adhoc-solo-version` from `.citr-env` — a default run uses the
  current pin, an explicit input still overrides. `extract-citr-vars` is now unconditional
  and a dependency of every scenario job (a skipped need would skip its dependents); install
  steps fail fast if unresolved.
- **`solo-e2e-*.sh`**: refresh the stale `solo 0.79.0` coupling comments → `0.79.1`.
