### PR TITLE
ci: bind tck/solo workflow inputs via env before shell

### DIFF
--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -132,7 +132,9 @@ jobs:
       # Install solo and configure to use the artifacts from
       # the hiero-consensus-node build
       - name: Install Solo
-        run: npm install -g @hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version || 'latest' }}
+        run: npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind

--- a/.github/workflows/819-call-tck-regression.yaml
+++ b/.github/workflows/819-call-tck-regression.yaml
@@ -104,19 +104,21 @@ jobs:
           fetch-tags: true
 
       - name: Checkout TCK Tag
+        env:
+          TCK_VERSION: ${{ inputs.tck-version }}
         run: |
           cd platform-sdk/regression
           git fetch --tags
 
           # Check out by tag first, then fall back to commit SHA.
-          if git rev-parse "refs/tags/${{ inputs.tck-version }}" >/dev/null 2>&1; then
-            echo "Checking out specified TCK version (tag): ${{ inputs.tck-version }}"
-            git checkout "tags/${{ inputs.tck-version }}"
-          elif git rev-parse --verify "${{ inputs.tck-version }}^{commit}" >/dev/null 2>&1; then
-            echo "Checking out specified TCK version (commit SHA): ${{ inputs.tck-version }}"
-            git checkout "${{ inputs.tck-version }}"
+          if git rev-parse "refs/tags/${TCK_VERSION}" >/dev/null 2>&1; then
+            echo "Checking out specified TCK version (tag): ${TCK_VERSION}"
+            git checkout "tags/${TCK_VERSION}"
+          elif git rev-parse --verify "${TCK_VERSION}^{commit}" >/dev/null 2>&1; then
+            echo "Checking out specified TCK version (commit SHA): ${TCK_VERSION}"
+            git checkout "${TCK_VERSION}"
           else
-            echo "Specified TCK version ${{ inputs.tck-version }} not found as a tag or commit SHA."
+            echo "Specified TCK version ${TCK_VERSION} not found as a tag or commit SHA."
             exit 1
           fi
 
@@ -189,8 +191,10 @@ jobs:
           echo "CN_VERSION=${RAW_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version || 'latest' }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 
       - name: Setup Kind

--- a/.github/workflows/821-call-block-node-regression.yaml
+++ b/.github/workflows/821-call-block-node-regression.yaml
@@ -160,18 +160,20 @@ jobs:
           fetch-tags: true
 
       - name: Checkout TCK Tag
+        env:
+          TCK_VERSION: ${{ inputs.tck-version }}
         run: |
           cd sdk-tck/regression
           git fetch --tags
           # Check out by tag first, then fall back to commit SHA.
-          if git rev-parse "refs/tags/${{ inputs.tck-version }}" >/dev/null 2>&1; then
-            echo "Checking out specified TCK version (tag): ${{ inputs.tck-version }}"
-            git checkout "tags/${{ inputs.tck-version }}"
-          elif git rev-parse --verify "${{ inputs.tck-version }}^{commit}" >/dev/null 2>&1; then
-            echo "Checking out specified TCK version (commit SHA): ${{ inputs.tck-version }}"
-            git checkout "${{ inputs.tck-version }}"
+          if git rev-parse "refs/tags/${TCK_VERSION}" >/dev/null 2>&1; then
+            echo "Checking out specified TCK version (tag): ${TCK_VERSION}"
+            git checkout "tags/${TCK_VERSION}"
+          elif git rev-parse --verify "${TCK_VERSION}^{commit}" >/dev/null 2>&1; then
+            echo "Checking out specified TCK version (commit SHA): ${TCK_VERSION}"
+            git checkout "${TCK_VERSION}"
           else
-            echo "Specified TCK version ${{ inputs.tck-version }} not found as a tag or commit SHA."
+            echo "Specified TCK version ${TCK_VERSION} not found as a tag or commit SHA."
             exit 1
           fi
 
@@ -241,12 +243,14 @@ jobs:
       # Install solo and configure to use the artifacts from
       # the hiero-consensus-node build
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version }}
         run: |
-          if [[ -z "${{ inputs.solo-version }}" ]]; then
+          if [[ -z "$SOLO_VERSION" ]]; then
             echo "ERROR: solo-version input must be set to a specific version tag (e.g. v0.44.0)"
             exit 1
           fi
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind

--- a/.github/workflows/830-call-merge-queue-performance-test.yaml
+++ b/.github/workflows/830-call-merge-queue-performance-test.yaml
@@ -285,8 +285,10 @@ jobs:
           wait: 120s
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version || 'latest' }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
 
           # verify the installation
           solo --version

--- a/.github/workflows/831-call-single-day-performance-test.yaml
+++ b/.github/workflows/831-call-single-day-performance-test.yaml
@@ -297,8 +297,10 @@ jobs:
           wait: 120s
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version || 'latest' }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
 
           # verify the installation
           solo --version

--- a/.github/workflows/833-call-single-day-longevity-test.yaml
+++ b/.github/workflows/833-call-single-day-longevity-test.yaml
@@ -272,8 +272,10 @@ jobs:
           wait: 120s
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version || 'latest' }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
 
           # verify the installation
           solo --version


### PR DESCRIPTION
## Summary
- Bind `inputs.tck-version` through `env:` before TCK tag/commit checkout shell steps.
- Bind `inputs.solo-version` through `env:` before `npm install -g @hiero-ledger/solo@…` shell steps across reusable regression workflows.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] TCK regression still checks out the requested tag/SHA
- [ ] Solo install still installs the requested version (or latest default where applicable)


Made with [Cursor](https://cursor.com)