### PR TITLE
fix: gossip timeout

### DIFF
--- a/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/RpcPeerHandler.java
+++ b/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/RpcPeerHandler.java
@@ -131,6 +131,16 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
     private volatile boolean communicationOverload = false;
 
     /**
+     * Last time the in-flight sync made progress; aborted if it stalls for {@link SyncConfig#maxSyncTime()}
+     */
+    private Instant lastSyncProgress;
+
+    /**
+     * Whether the no-progress timeout has already broken this conversation, so we only break it once
+     */
+    private boolean syncBreakRequested = false;
+
+    /**
      * Create new state class for an RPC peer
      *
      * @param sharedShadowgraphSynchronizer shared logic reference for actions which have to work against global state
@@ -172,6 +182,7 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
         this.fallenBehindMonitor = fallenBehindMonitor;
         this.fallBehindRateLimiter = new RateLimiter(time, Duration.ofMinutes(1));
         this.lastReceiveEventFinished = time.nanoTime();
+        this.lastSyncProgress = time.now();
         this.syncConfig = Objects.requireNonNull(syncConfig);
         this.broadcastConfig = Objects.requireNonNull(broadcastConfig);
     }
@@ -185,6 +196,12 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
     public boolean checkForPeriodicActions(final boolean wantToExit, final boolean ignoreIncomingEvents) {
 
         this.ignoreIncomingEvents = ignoreIncomingEvents;
+
+        // abort a stalled sync; checked before the guards below, which short-circuit while a sync is waiting
+        if (!syncBreakRequested && isSyncStalled()) {
+            abortStalledSync();
+            return !wantToExit;
+        }
 
         if (!isSyncCooldownComplete()) {
             this.syncMetrics.doNotSyncCooldown();
@@ -241,6 +258,8 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
         }
         clearInternalState();
         state.peerStillSendingEvents = false;
+        syncBreakRequested = false;
+        lastSyncProgress = time.now();
         this.syncMetrics.reportSyncPhase(peerId, SyncPhase.OUTSIDE_OF_RPC);
         // mark sync as never happened to stop broadcast from running
         state.lastSyncFinishedTime = Instant.MIN;
@@ -280,6 +299,7 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
     @Override
     public void receiveSyncData(@NonNull final SyncData syncMessage) {
 
+        recordSyncProgress();
         this.syncMetrics.reportSyncPhase(peerId, SyncPhase.EXCHANGING_WINDOWS);
         this.syncMetrics.acceptedSyncRequest();
 
@@ -294,6 +314,7 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
     @Override
     public void receiveTips(@NonNull final List<Boolean> remoteTipKnowledge) {
 
+        recordSyncProgress();
         if (state.mySyncData == null) {
             throw new IllegalStateException("Received tips confirmation before sending sync data from " + peerId);
         }
@@ -335,6 +356,7 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
      */
     @Override
     public void receiveEvents(@NonNull final List<GossipEvent> gossipEvents) {
+        recordSyncProgress();
         final SyncData mySyncData = state.mySyncData;
         if (mySyncData != null && mySyncData.dontReceiveEvents()) {
             // we ignore all incoming events - they should not be sent to us in first place
@@ -354,6 +376,7 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
      */
     @Override
     public void receiveEventsFinished() {
+        recordSyncProgress();
         if (state.mySyncData == null) {
             // have we already finished sending out events? if yes, mark the sync as finished
             reportSyncFinished();
@@ -444,6 +467,7 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
     }
 
     private void sendSyncData(final boolean ignoreIncomingEvents) {
+        recordSyncProgress();
         syncMetrics.syncStarted();
         this.syncMetrics.reportSyncPhase(peerId, SyncPhase.EXCHANGING_WINDOWS);
         state.shadowWindow = sharedShadowgraphSynchronizer.reserveEventWindow();
@@ -501,6 +525,35 @@ public class RpcPeerHandler implements GossipRpcReceiverHandler {
             syncGuard.onSyncCompleted(peerId);
         }
         state.clear(time.now());
+    }
+
+    /**
+     * Resets the no-progress timeout because the sync advanced. Deliberately not called for pings.
+     */
+    private void recordSyncProgress() {
+        lastSyncProgress = time.now();
+    }
+
+    /**
+     * @return true if a sync is in progress but has not advanced within {@link SyncConfig#maxSyncTime()}
+     */
+    private boolean isSyncStalled() {
+        final boolean syncInProgress = state.mySyncData != null || state.peerStillSendingEvents;
+        return syncInProgress
+                && isGreaterThanOrEqualTo(Duration.between(lastSyncProgress, time.now()), syncConfig.maxSyncTime());
+    }
+
+    /**
+     * Breaks a stalled sync so the connection is torn down and re-negotiated.
+     */
+    private void abortStalledSync() {
+        syncBreakRequested = true;
+        logger.warn(
+                SYNC_INFO.getMarker(),
+                "Sync with {} made no progress for {}; aborting the conversation so it can be re-negotiated",
+                peerId,
+                syncConfig.maxSyncTime());
+        sender.breakConversation();
     }
 
     /**

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/RpcPeerHandlerTimeoutTest.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/RpcPeerHandlerTimeoutTest.java
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.gossip.impl.gossip.shadowgraph;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.swirlds.base.test.fixtures.time.FakeTime;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import java.time.Duration;
+import java.util.List;
+import org.hiero.consensus.event.IntakeEventCounter;
+import org.hiero.consensus.gossip.config.BroadcastConfig;
+import org.hiero.consensus.gossip.config.SyncConfig;
+import org.hiero.consensus.gossip.impl.gossip.permits.SyncGuard;
+import org.hiero.consensus.gossip.impl.gossip.rpc.GossipRpcSender;
+import org.hiero.consensus.gossip.impl.gossip.sync.SyncMetrics;
+import org.hiero.consensus.model.hashgraph.EventWindow;
+import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.monitoring.FallenBehindMonitor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link RpcPeerHandler} aborts a sync that stalls with no progress for
+ * {@link SyncConfig#maxSyncTime()}, while leaving a sync that keeps making progress alone.
+ */
+class RpcPeerHandlerTimeoutTest {
+
+    private static final NodeId SELF = NodeId.of(0L);
+    private static final NodeId PEER = NodeId.of(1L);
+    private static final Duration MAX_SYNC_TIME = Duration.ofSeconds(30);
+
+    @Test
+    void stalledSyncIsAbortedAfterMaxSyncTime() {
+        final FakeTime time = new FakeTime();
+
+        final Configuration configuration =
+                new TestConfigBuilder().withValue("sync.maxSyncTime", "30s").getOrCreateConfig();
+        final SyncConfig syncConfig = configuration.getConfigData(SyncConfig.class);
+        final BroadcastConfig broadcastConfig = configuration.getConfigData(BroadcastConfig.class);
+
+        final GossipRpcSender sender = mock(GossipRpcSender.class);
+
+        // enough of the synchronizer for the handler to start a sync
+        final ShadowgraphSynchronizer synchronizer = mock(ShadowgraphSynchronizer.class);
+        final ReservedEventWindow reservedWindow = mock(ReservedEventWindow.class);
+        when(reservedWindow.getEventWindow()).thenReturn(EventWindow.getGenesisEventWindow());
+        when(synchronizer.reserveEventWindow()).thenReturn(reservedWindow);
+        when(synchronizer.getTips()).thenReturn(List.of());
+
+        final SyncGuard syncGuard = mock(SyncGuard.class);
+        when(syncGuard.isSyncAllowed(any())).thenReturn(true);
+
+        final IntakeEventCounter intakeEventCounter = mock(IntakeEventCounter.class);
+        when(intakeEventCounter.hasUnprocessedEvents(any())).thenReturn(false);
+
+        final RpcPeerHandler handler = new RpcPeerHandler(
+                synchronizer,
+                sender,
+                SELF,
+                PEER,
+                mock(SyncMetrics.class),
+                time,
+                intakeEventCounter,
+                event -> {},
+                syncGuard,
+                mock(FallenBehindMonitor.class),
+                syncConfig,
+                broadcastConfig);
+
+        // first tick starts a sync; the peer never replies
+        handler.checkForPeriodicActions(false, false);
+        verify(sender).sendSyncData(any());
+
+        // just short of maxSyncTime: not aborted yet
+        time.tick(MAX_SYNC_TIME.minusSeconds(1));
+        handler.checkForPeriodicActions(false, false);
+        verify(sender, never()).breakConversation();
+
+        // past maxSyncTime with no progress: aborted
+        time.tick(Duration.ofSeconds(2));
+        handler.checkForPeriodicActions(false, false);
+        verify(sender).breakConversation();
+
+        // must break only once
+        time.tick(MAX_SYNC_TIME);
+        handler.checkForPeriodicActions(false, false);
+        verify(sender, times(1)).breakConversation();
+    }
+
+    @Test
+    void progressingSyncIsNotAborted() {
+        final FakeTime time = new FakeTime();
+
+        final Configuration configuration =
+                new TestConfigBuilder().withValue("sync.maxSyncTime", "30s").getOrCreateConfig();
+        final SyncConfig syncConfig = configuration.getConfigData(SyncConfig.class);
+        final BroadcastConfig broadcastConfig = configuration.getConfigData(BroadcastConfig.class);
+
+        final GossipRpcSender sender = mock(GossipRpcSender.class);
+
+        final ShadowgraphSynchronizer synchronizer = mock(ShadowgraphSynchronizer.class);
+        final ReservedEventWindow reservedWindow = mock(ReservedEventWindow.class);
+        when(reservedWindow.getEventWindow()).thenReturn(EventWindow.getGenesisEventWindow());
+        when(synchronizer.reserveEventWindow()).thenReturn(reservedWindow);
+        when(synchronizer.getTips()).thenReturn(List.of());
+
+        final SyncGuard syncGuard = mock(SyncGuard.class);
+        when(syncGuard.isSyncAllowed(any())).thenReturn(true);
+
+        final IntakeEventCounter intakeEventCounter = mock(IntakeEventCounter.class);
+        when(intakeEventCounter.hasUnprocessedEvents(any())).thenReturn(false);
+
+        final RpcPeerHandler handler = new RpcPeerHandler(
+                synchronizer,
+                sender,
+                SELF,
+                PEER,
+                mock(SyncMetrics.class),
+                time,
+                intakeEventCounter,
+                event -> {},
+                syncGuard,
+                mock(FallenBehindMonitor.class),
+                syncConfig,
+                broadcastConfig);
+
+        // start a sync
+        handler.checkForPeriodicActions(false, false);
+        verify(sender).sendSyncData(any());
+
+        // a sync that keeps receiving events is making progress and must never be aborted
+        for (int i = 0; i < 5; i++) {
+            time.tick(MAX_SYNC_TIME.minusSeconds(1));
+            handler.receiveEvents(List.of()); // counts as progress
+            handler.checkForPeriodicActions(false, false);
+        }
+        verify(sender, never()).breakConversation();
+    }
+}


### PR DESCRIPTION
**Description**:

A gossip sync can stall during the event-window handshake: a node sends its `SyncData` and waits for the peer's reply. If the peer is degraded and never sends a reply, and pings keep the TCP connection alive, the socket read timeout never fires. The sync has no application-level timeout and wedges indefinitely. The node holds the connection.

This PR adds a no-progress timeout in `RpcPeerHandler`. It tracks when the in-flight sync last advanced. If no progress is made for `maxSyncTime`, it breaks the conversation, so the connection is torn down and re-negotiated.

**Related issue(s)**:

Fixes #26472 
