### PR TITLE
fix: reject throttle buckets with no throttle groups

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleParser.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleParser.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.throttle;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.BUCKET_HAS_NO_THROTTLE_GROUPS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OPERATION_REPEATED_IN_BUCKET_GROUPS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS_BUT_MISSING_EXPECTED_OPERATION;
@@ -81,9 +82,21 @@ public class ThrottleParser {
      * Checks if the throttle definitions are valid.
      */
     private void validate(ThrottleDefinitions throttleDefinitions) {
+        checkForEmptyBuckets(throttleDefinitions);
         checkForZeroOpsPerSec(throttleDefinitions);
         checkForRepeatedOperations(throttleDefinitions);
         validateLeastCommonMultipleDoesNotOverflow(throttleDefinitions);
+    }
+
+    /**
+     * Checks if there are throttle buckets defined with no throttle groups.
+     */
+    private void checkForEmptyBuckets(ThrottleDefinitions throttleDefinitions) {
+        for (var bucket : throttleDefinitions.throttleBuckets()) {
+            if (bucket.throttleGroups().isEmpty()) {
+                throw new HandleException(BUCKET_HAS_NO_THROTTLE_GROUPS);
+            }
+        }
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleParserTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleParserTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.throttle;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.BUCKET_HAS_NO_THROTTLE_GROUPS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OPERATION_REPEATED_IN_BUCKET_GROUPS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS_BUT_MISSING_EXPECTED_OPERATION;
@@ -100,6 +101,18 @@ class ThrottleParserTest {
         assertThatThrownBy(() -> subject.parse(bytes))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC));
+    }
+
+    @Test
+    void parseWithEmptyBucket_throwsBucketHasNoThrottleGroups() {
+        final var bucket =
+                ThrottleBucket.newBuilder().name("bucket").burstPeriodMs(100L).build();
+        final var bytes = ThrottleDefinitions.PROTOBUF.toBytes(
+                ThrottleDefinitions.newBuilder().throttleBuckets(bucket).build());
+
+        assertThatThrownBy(() -> subject.parse(bytes))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(BUCKET_HAS_NO_THROTTLE_GROUPS));
     }
 
     @Test


### PR DESCRIPTION
**Description**:
ThrottleParser never checked for a bucket with an empty throttle-group list. An empty bucket slips past the zero-ops and repeated-op checks (their inner loops just don’t run) and then hits throttleGroups.get(0) in leastCommonMultiple, throwing an IndexOutOfBoundsException. Nothing catches that as a HandleException, so instead of a clear validation error the update fails with an opaque FAIL_INVALID and logs an alert-level stacktrace on every node.

This adds an explicit empty-bucket check to validate() that throws HandleException(BUCKET_HAS_NO_THROTTLE_GROUPS), the same response code the legacy ThrottleBucket path already uses for this case. Valid throttle files behave exactly as before. Added a unit test for the empty-bucket case.