### PR TITLE
chore: Fix outdated method calls

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamEventBuilder.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamEventBuilder.java
@@ -231,7 +231,7 @@ public class BlockStreamEventBuilder {
                     final int parentIndex = parentRef.parent().as();
                     final PlatformEvent parent = eventIndexToEvent.get(parentIndex);
                     if (parent != null) {
-                        resolvedParents.add(parent.getDescriptor().eventDescriptor());
+                        resolvedParents.add(parent.getDescriptor().toPbj());
                     } else {
                         throw new IllegalStateException("Unable to find a parent event for index " + parentIndex);
                     }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/StaleParentTracker.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/StaleParentTracker.java
@@ -101,7 +101,7 @@ final class StaleParentTracker {
             if (stale.containsKey(ph) || boundary.containsKey(ph)) {
                 continue; // already classified via another child
             }
-            final long pbr = parent.eventDescriptor().birthRound();
+            final long pbr = parent.toPbj().birthRound();
             if (pbr >= windowStart) {
                 stale.put(ph, new RefInfo(parent.creator().id(), pbr, childCreator, childBirthRound));
             } else {


### PR DESCRIPTION
**Description**:

A method in `EventDescriptorWrapper` was recently renamed. Two call sites were missed.

**Related issue(s)**:

Fixes #26733 