### PR TITLE
ci(workflow-fix): fix extra arg in MATS failure slack report

### DIFF
--- a/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
+++ b/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
@@ -18,7 +18,7 @@
           "type": "section",
           "text": {
             "type": "mrkdwn",
-            "text": {{ printf "*MATS test failure on `%s`. See status below.* " (getenv "REF_NAME" | required "REF_NAME must be set") (getenv "REF_NAME") | data.ToJSON }}
+            "text": {{ printf "*MATS test failure on `%s`. See status below.* " (getenv "REF_NAME" | required "REF_NAME must be set") | data.ToJSON }}
           },
           "fields": [
             {


### PR DESCRIPTION
**Description**:

Remove the extra arg from the MATS failure slack report template.

**Related Issue(s)**:

Fixes #26738
